### PR TITLE
Fix Railway build and deployment issues

### DIFF
--- a/the_flip/settings/__init__.py
+++ b/the_flip/settings/__init__.py
@@ -1,0 +1,2 @@
+# Allows importing this directory as a Python module (defaults to dev settings)
+from .dev import *  # noqa: F403, F401


### PR DESCRIPTION
## Summary
- Fixed Railway build failure caused by `make test-ci` command not being available
- Replaced with direct Django test command using `python manage.py test`
- Made Python command consistent with rest of build script (no venv path)
- Fixed deployment error by restoring settings `__init__.py` import that was removed by linters

## Changes
1. **build.sh**: Replaced `make test-ci` with direct Django command
2. **the_flip/settings/__init__.py**: Added back the dev settings import with `noqa` to prevent linters from removing it again

## Test plan
- [ ] Verify Railway build succeeds
- [ ] Verify Railway deployment starts without AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)