### PR TITLE
Create static_collected directory before running tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,9 @@ set -o errexit
 # Install dependencies
 pip install -r requirements.txt
 
-# Create media directory if it doesn't exist
+# Create directories if they don't exist
 mkdir -p media
+mkdir -p static_collected
 
 # Run tests
 echo "Running tests..."


### PR DESCRIPTION
## Summary
WhiteNoise middleware checks for the static files directory during initialization, which happens when Django loads during tests. This causes a warning on Railway builds:

```
/app/the_flip/middleware.py:15: UserWarning: No directory at: /app/static_collected/
```

## Changes
Create the `static_collected` directory before running tests, similar to how we create the `media` directory.

## Test plan
- [ ] Verify Railway build completes without the WhiteNoise warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)