### PR TITLE
Revert settings __init__.py to empty file

### DIFF
--- a/the_flip/settings/__init__.py
+++ b/the_flip/settings/__init__.py
@@ -1,2 +1,0 @@
-# Allows importing this directory as a Python module (defaults to dev settings)
-from .dev import *  # noqa: F403, F401


### PR DESCRIPTION
## Summary
The import in settings/__init__.py was causing build failures. Reverting to an empty file.

Railway has `DJANGO_SETTINGS_MODULE=the_flip.settings.prod` set as an environment variable, which should be sufficient to load the correct settings.

## Changes
- Remove the `from .dev import *` line from settings/__init__.py

## Test plan
- [ ] Verify Railway build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)