### PR TITLE
Add debug output to identify Railway build failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,11 @@ DJANGO_SETTINGS_MODULE=the_flip.settings.test python manage.py test
 echo "✓ All tests passed"
 
 # Run migrations
+echo "Running migrations..."
 python manage.py migrate
+echo "✓ Migrations complete"
 
 # Collect static files
+echo "Collecting static files..."
 python manage.py collectstatic --no-input
+echo "✓ Static files collected"


### PR DESCRIPTION
## Summary
The Railway build is failing after tests pass, but we don't know if it's failing during migrations or collectstatic. This adds debug output to identify the exact failure point.

## Changes
- Added echo statements before and after migrations
- Added echo statements before and after collectstatic

## Test plan
- [ ] Check Railway build logs to see where it's actually failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)