### PR TITLE
Fix Railway database configuration and add error messages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,10 +18,10 @@ echo "✓ All tests passed"
 
 # Run migrations
 echo "Running migrations..."
-python manage.py migrate
+DJANGO_SETTINGS_MODULE=the_flip.settings.prod python manage.py migrate
 echo "✓ Migrations complete"
 
 # Collect static files
 echo "Collecting static files..."
-python manage.py collectstatic --no-input
+DJANGO_SETTINGS_MODULE=the_flip.settings.prod python manage.py collectstatic --no-input
 echo "✓ Static files collected"

--- a/the_flip/settings/prod.py
+++ b/the_flip/settings/prod.py
@@ -35,14 +35,19 @@ else:
     db_type = "public"
 
 if not active_db_url:
+    print(
+        f"ERROR: No database URL found. DATABASE_URL={bool(database_url)}, DATABASE_PUBLIC_URL={bool(database_public_url)}, RAILWAY_DEPLOYMENT_ID={bool(os.environ.get('RAILWAY_DEPLOYMENT_ID'))}",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 if not active_db_url.startswith("postgres"):
+    print(f"ERROR: Database URL must be PostgreSQL. Got: {active_db_url[:20]}...", file=sys.stderr)
     sys.exit(1)
 
 
 DATABASES = {
-    "default": dj_database_url.parse(
+    "default": dj_database_url.parse(  # type: ignore[dict-item]
         active_db_url,
         conn_max_age=600,
         conn_health_checks=True,


### PR DESCRIPTION
## Summary
- Set `DJANGO_SETTINGS_MODULE=the_flip.settings.prod` for migrations and collectstatic commands
- Add helpful error messages when database URL is missing or invalid instead of silently exiting

## Changes
1. **build.sh**: Added `DJANGO_SETTINGS_MODULE=the_flip.settings.prod` to migrations and collectstatic
2. **the_flip/settings/prod.py**: Added error messages showing which database env vars are available when config fails

## Test plan
- [ ] Verify Railway build completes successfully or shows clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)