### PR TITLE
Add GitHub Actions CI workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ffmpeg
+        sudo apt-get install -y libheif1 libheif-dev ffmpeg
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs on pushes to main and all pull requests
- Run Django tests with Python 3.13 and PostgreSQL 15 (matching production)
- Cache pip dependencies for faster builds
- Include optional linting and type checking steps

## Benefits
- Tests will run automatically on every PR before merging
- Catch issues earlier in the development process
- Faster feedback than waiting for Railway deployment
- Railway deployment still runs tests as a final safety check

## Test plan
- [ ] Verify CI runs successfully on this PR
- [ ] Check that tests pass in the GitHub Actions workflow
- [ ] Confirm workflow appears in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)