### PR TITLE
Remove startCommand from railway.toml to allow per-service configuration

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -5,7 +5,11 @@ builder = "NIXPACKS"
 buildCommand = "./build.sh"
 
 [deploy]
-startCommand = "gunicorn the_flip.wsgi:application"
+# startCommand intentionally omitted - configure per service:
+#   - In Railway dashboard for each service, or
+#   - Via NIXPACKS_START_CMD environment variable
+# Web service should run: gunicorn the_flip.wsgi:application
+# Worker service should run: DJANGO_SETTINGS_MODULE=the_flip.settings.prod python manage.py qcluster
 # Disable Railway health checks (blank path/null per Railway docs)
 healthcheckPath = ""
 healthcheckTimeout = 100


### PR DESCRIPTION
## Summary
- Removed `startCommand` from `railway.toml` to allow each Railway service to configure its own start command
- This fixes the issue where the worker service was running `gunicorn` instead of `qcluster`, causing video transcoding jobs to queue but never process

## Problem
The worker service couldn't override the `startCommand` in `railway.toml`, so it was running the web server (`gunicorn`) instead of the Django Q worker (`qcluster`). This caused all video transcoding jobs to queue up but never get processed.

## Solution
By removing `startCommand` from `railway.toml`, each service can now set its own via the `NIXPACKS_START_CMD` environment variable:
- **Web service**: `NIXPACKS_START_CMD=gunicorn the_flip.wsgi:application`
- **Worker service**: `NIXPACKS_START_CMD=DJANGO_SETTINGS_MODULE=the_flip.settings.prod python manage.py qcluster`

## Railway Configuration Steps
After merging this PR, configure each service in Railway dashboard:

### Web Service
Add environment variable:
- **Name**: `NIXPACKS_START_CMD`
- **Value**: `gunicorn the_flip.wsgi:application`

### Worker Service
Add environment variable:
- **Name**: `NIXPACKS_START_CMD`
- **Value**: `DJANGO_SETTINGS_MODULE=the_flip.settings.prod python manage.py qcluster`

Both services will redeploy automatically after adding the env var.

## Test Plan
- [x] Commit passes pre-commit hooks
- [ ] After merge + Railway config: Upload test video through web interface
- [ ] Verify worker service logs show qcluster starting up
- [ ] Verify video transcoding completes successfully
- [ ] Verify transcoded video appears and plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)