### PR TITLE
Improve transcoding error messages and FFmpeg logging

### DIFF
--- a/the_flip/apps/maintenance/tasks.py
+++ b/the_flip/apps/maintenance/tasks.py
@@ -257,4 +257,16 @@ def _probe_duration_seconds(input_path: Path) -> int | None:
 def _run_ffmpeg(cmd: list[str]):
     """Run ffmpeg/ffprobe with basic logging."""
     logger.info("Running command: %s", " ".join(cmd))
-    subprocess.run(cmd, check=True)
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        if result.stdout:
+            logger.debug("FFmpeg stdout: %s", result.stdout)
+        if result.stderr:
+            logger.debug("FFmpeg stderr: %s", result.stderr)
+    except subprocess.CalledProcessError as e:
+        logger.error("FFmpeg command failed with exit code %d", e.returncode)
+        if e.stdout:
+            logger.error("FFmpeg stdout: %s", e.stdout)
+        if e.stderr:
+            logger.error("FFmpeg stderr: %s", e.stderr)
+        raise


### PR DESCRIPTION
## Summary
- Improve environment variable error messages to list specific missing variables
- Capture and log FFmpeg stderr output for better debugging

## Changes

### Better Environment Variable Error Messages
Previously, when environment variables were missing, the error message said "DJANGO_WEB_SERVICE_URL and TRANSCODING_UPLOAD_TOKEN must be configured" regardless of which variable was actually missing.

Now it specifically lists which variables are missing:
- "Required environment variables not configured: DJANGO_WEB_SERVICE_URL"
- "Required environment variables not configured: TRANSCODING_UPLOAD_TOKEN"
- "Required environment variables not configured: DJANGO_WEB_SERVICE_URL, TRANSCODING_UPLOAD_TOKEN"

### FFmpeg Error Logging
Previously, when FFmpeg commands failed, we only saw the exit code but not the actual error message from FFmpeg. This made it impossible to diagnose issues like:
- Missing codecs
- Corrupted input files
- Configuration problems
- Resource exhaustion

Now we capture both stdout and stderr, logging them at:
- Debug level for successful runs
- Error level for failures

This will help diagnose the current FFmpeg exit status 254 error on Railway.

## Test plan
- [x] Deploy to Railway worker service
- [ ] Check worker logs when transcoding fails to see specific error messages
- [ ] Use error messages to identify root cause (missing codecs, file issues, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)