### PR TITLE
Skip CI workflow for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to CI workflow to skip tests, linting, and type checking when only documentation files change
- Saves CI resources and speeds up documentation PRs

## Changes
- Ignore `**.md` (all markdown files)
- Ignore `docs/**` (all files in docs directory)

## Test plan
- [ ] Verify this PR triggers CI (since it changes a workflow file)
- [ ] Create a test PR with only markdown changes and verify CI is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)