### PR TITLE
Remove obsolete LOCATION_FLOOR references from tests

### DIFF
--- a/the_flip/apps/maintenance/tests.py
+++ b/the_flip/apps/maintenance/tests.py
@@ -745,7 +745,6 @@ class LogEntryWorkDateTests(TestCase):
         self.machine = MachineInstance.objects.create(
             model=self.machine_model,
             slug="test-machine",
-            location=MachineInstance.LOCATION_FLOOR,
             operational_status=MachineInstance.STATUS_GOOD,
         )
 
@@ -844,7 +843,6 @@ class MachineLogCreateViewWorkDateTests(TestCase):
         self.machine = MachineInstance.objects.create(
             model=self.machine_model,
             slug="test-machine",
-            location=MachineInstance.LOCATION_FLOOR,
             operational_status=MachineInstance.STATUS_GOOD,
         )
         self.staff_user = User.objects.create_user(
@@ -911,7 +909,6 @@ class LogEntryDetailViewWorkDateTests(TestCase):
         self.machine = MachineInstance.objects.create(
             model=self.machine_model,
             slug="test-machine",
-            location=MachineInstance.LOCATION_FLOOR,
             operational_status=MachineInstance.STATUS_GOOD,
         )
         self.log_entry = LogEntry.objects.create(

--- a/the_flip/apps/maintenance/views.py
+++ b/the_flip/apps/maintenance/views.py
@@ -421,9 +421,7 @@ class LogEntryDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
                 self.object.save(update_fields=["work_date", "updated_at"])
                 return JsonResponse({"success": True})
             except ValueError:
-                return JsonResponse(
-                    {"success": False, "error": "Invalid date format"}, status=400
-                )
+                return JsonResponse({"success": False, "error": "Invalid date format"}, status=400)
 
         elif action == "upload_media":
             if "file" in request.FILES:


### PR DESCRIPTION
## Summary
- Fix test failures caused by references to `MachineInstance.LOCATION_FLOOR` which no longer exists
- The Location model refactor (ec5b8b2) changed `location` from a CharField with choices to a ForeignKey
- Three test classes added afterward still used the old constant
- Since `location` is now nullable, simply omit it from test fixtures

## Test plan
- [x] All 61 tests pass locally
- [x] Quality checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)