### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Flip Pinball Musuem's Maintenance System
 
+[![CI](https://github.com/deanmoses/the_flip/actions/workflows/ci.yml/badge.svg)](https://github.com/deanmoses/the_flip/actions/workflows/ci.yml)
+
 This is a web app for managing pinball machine problem reports at The Flip pinball museum.
 
 It allows museum visitors to report problems with pinball machines (via QR codes on each machine), and enables maintainers to track, update, and resolve these issues.


### PR DESCRIPTION
## Summary
- Adds a CI status badge to the README that shows whether tests are passing
- Links to the GitHub Actions workflow runs page

## Test plan
- [ ] Verify badge displays correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)