### PR TITLE
Add maintainer profile management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test:
 
 .PHONY: runserver
 runserver:
+	@pkill -f "manage.py runserver" 2>/dev/null || true
 	.venv/bin/python manage.py runserver
 
 .PHONY: migrate

--- a/docs/HTML_CSS.md
+++ b/docs/HTML_CSS.md
@@ -28,6 +28,7 @@ The project establishes component patterns in [the_flip/static/core/styles.css](
 - **Machine Cards** (`.machine-card` with structured BEM elements)
 - **Forms** (`.form-field` wrapper pattern)
 - **Messages & Alerts** (`.message` with type modifiers)
+- **User Menu** (`.user-menu` with `.user-menu__avatar`, `.user-menu__dropdown`, `.user-menu__item`)
 - **Utility classes** (`.hidden`, `.text-muted`, `.badge-right`)
 
 **Do not introduce new component patterns without documenting them here**.

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Profile · {{ block.super }}{% endblock %}
+{% block content %}
+  <h2>Profile</h2>
+  <form method="post">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+      <div class="form-errors">
+        {% for error in form.non_field_errors %}<p class="error">{{ error }}</p>{% endfor %}
+      </div>
+    {% endif %}
+    <div class="form-field">
+      <label for="id_email">Email</label>
+      <input type="email"
+             name="email"
+             id="id_email"
+             value="{{ form.email.value|default:'' }}"
+             required
+             autocomplete="email">
+      {% for error in form.email.errors %}<p class="error">{{ error }}</p>{% endfor %}
+    </div>
+    <div class="form-field">
+      <label for="id_first_name">First name</label>
+      <input type="text"
+             name="first_name"
+             id="id_first_name"
+             value="{{ form.first_name.value|default:'' }}"
+             autocomplete="given-name">
+      {% for error in form.first_name.errors %}<p class="error">{{ error }}</p>{% endfor %}
+    </div>
+    <div class="form-field">
+      <label for="id_last_name">Last name</label>
+      <input type="text"
+             name="last_name"
+             id="id_last_name"
+             value="{{ form.last_name.value|default:'' }}"
+             autocomplete="family-name">
+      {% for error in form.last_name.errors %}<p class="error">{{ error }}</p>{% endfor %}
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Save Changes</button>
+    </div>
+  </form>
+  <hr>
+  <p>
+    <a href="{% url 'password_change' %}">Change Password</a>
+  </p>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,11 +23,27 @@
         <a href="{% url 'problem-report-list' %}">Problem Reports</a>
         <a href="{% url 'log-list' %}">Logs</a>
         {% if user.is_authenticated %}
-          <span>{{ user.username }}</span>
-          <form method="post" action="{% url 'logout' %}" style="display: inline;">
-            {% csrf_token %}
-            <button type="submit" class="nav-logout-btn">Logout</button>
-          </form>
+          <div class="user-menu">
+            <button type="button"
+                    class="user-menu__avatar"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+              {% if user.first_name and user.last_name %}
+                {{ user.first_name|make_list|first }}{{ user.last_name|make_list|first }}
+              {% elif user.first_name %}
+                {{ user.first_name|make_list|first }}
+              {% else %}
+                {{ user.username|make_list|first }}
+              {% endif %}
+            </button>
+            <div class="user-menu__dropdown">
+              <a href="{% url 'profile' %}" class="user-menu__item">Profile</a>
+              <form method="post" action="{% url 'logout' %}">
+                {% csrf_token %}
+                <button type="submit" class="user-menu__item">Logout</button>
+              </form>
+            </div>
+          </div>
         {% else %}
           <a href="{% url 'login' %}">Login</a>
         {% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -22,9 +22,15 @@
       <h3>Admin</h3>
       <p>This only appears for admins.</p>
       <ul>
-        <li><a href="{% url 'admin:accounts_invitation_add' %}">Invite new user</a></li>
-        <li><a href="{% url 'admin:catalog_location_changelist' %}">Manage locations</a></li>
-        <li><a href="{% url 'admin:index' %}">Admin home</a></li>
+        <li>
+          <a href="{% url 'admin:accounts_invitation_add' %}">Invite new user</a>
+        </li>
+        <li>
+          <a href="{% url 'admin:catalog_location_changelist' %}">Manage locations</a>
+        </li>
+        <li>
+          <a href="{% url 'admin:index' %}">Admin home</a>
+        </li>
       </ul>
     </div>
   {% endif %}

--- a/templates/registration/password_change_done.html
+++ b/templates/registration/password_change_done.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Password Changed · {{ block.super }}{% endblock %}
+{% block content %}
+  <h2>Password Changed</h2>
+  <p>Your password has been changed successfully.</p>
+  <p>
+    <a href="{% url 'profile' %}">Return to Profile</a>
+  </p>
+{% endblock %}

--- a/templates/registration/password_change_form.html
+++ b/templates/registration/password_change_form.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block title %}Change Password · {{ block.super }}{% endblock %}
+{% block content %}
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="breadcrumb__trail">
+      <a href="{% url 'profile' %}">Profile</a>
+      <span>›</span>
+      <strong>Change Password</strong>
+    </div>
+  </nav>
+  <h2>Change Password</h2>
+  <form method="post">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+      <div class="form-errors">
+        {% for error in form.non_field_errors %}<p class="error">{{ error }}</p>{% endfor %}
+      </div>
+    {% endif %}
+    <div class="form-field">
+      <label for="id_old_password">Current password</label>
+      <input type="password"
+             name="old_password"
+             id="id_old_password"
+             required
+             autocomplete="current-password">
+      {% for error in form.old_password.errors %}<p class="error">{{ error }}</p>{% endfor %}
+    </div>
+    <div class="form-field">
+      <label for="id_new_password1">New password</label>
+      <input type="password"
+             name="new_password1"
+             id="id_new_password1"
+             required
+             autocomplete="new-password">
+      {% for error in form.new_password1.errors %}<p class="error">{{ error }}</p>{% endfor %}
+    </div>
+    <div class="form-field">
+      <label for="id_new_password2">Confirm new password</label>
+      <input type="password"
+             name="new_password2"
+             id="id_new_password2"
+             required
+             autocomplete="new-password">
+      {% for error in form.new_password2.errors %}<p class="error">{{ error }}</p>{% endfor %}
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Change Password</button>
+      <a href="{% url 'profile' %}" class="btn btn-secondary">Cancel</a>
+    </div>
+  </form>
+{% endblock %}

--- a/the_flip/apps/accounts/admin.py
+++ b/the_flip/apps/accounts/admin.py
@@ -48,9 +48,7 @@ class InvitationAdmin(admin.ModelAdmin):
 
     def response_add(self, request, obj, post_url_continue=None):
         """After creating an invitation, redirect to its detail page to show the link."""
-        return HttpResponseRedirect(
-            reverse("admin:accounts_invitation_change", args=[obj.pk])
-        )
+        return HttpResponseRedirect(reverse("admin:accounts_invitation_change", args=[obj.pk]))
 
     @admin.display(description="Registration Link")
     def registration_link(self, obj):

--- a/the_flip/apps/accounts/forms.py
+++ b/the_flip/apps/accounts/forms.py
@@ -45,3 +45,17 @@ class InvitationRegistrationForm(forms.Form):
         if password and password_confirm and password != password_confirm:
             self.add_error("password_confirm", "Passwords do not match.")
         return cleaned_data
+
+
+class ProfileForm(forms.ModelForm):
+    """Form for users to update their profile information."""
+
+    class Meta:
+        model = User
+        fields = ["email", "first_name", "last_name"]
+
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        if User.objects.filter(email=email).exclude(pk=self.instance.pk).exists():
+            raise forms.ValidationError("This email is already registered.")
+        return email

--- a/the_flip/apps/accounts/tests.py
+++ b/the_flip/apps/accounts/tests.py
@@ -213,3 +213,191 @@ class InvitationAdminTests(TestCase):
         response = self.client.post(add_url, {"email": "invite@example.com"})
         self.assertEqual(response.status_code, 302)  # Redirect after success
         self.assertTrue(Invitation.objects.filter(email="invite@example.com").exists())
+
+
+class ProfileViewTests(TestCase):
+    """Tests for the profile view."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            first_name="Test",
+            last_name="User",
+        )
+        self.profile_url = reverse("profile")
+
+    def test_profile_requires_login(self):
+        """Profile page should require login."""
+        response = self.client.get(self.profile_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response.url)
+
+    def test_profile_loads_for_authenticated_user(self):
+        """Profile page should load for authenticated users."""
+        self.client.login(username="testuser", password="testpass123")
+        response = self.client.get(self.profile_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/profile.html")
+
+    def test_profile_displays_current_data(self):
+        """Profile form should show current user data."""
+        self.client.login(username="testuser", password="testpass123")
+        response = self.client.get(self.profile_url)
+        self.assertContains(response, 'value="test@example.com"')
+        self.assertContains(response, 'value="Test"')
+        self.assertContains(response, 'value="User"')
+
+    def test_profile_update_saves_changes(self):
+        """Profile update should save changes."""
+        self.client.login(username="testuser", password="testpass123")
+        data = {
+            "email": "updated@example.com",
+            "first_name": "Updated",
+            "last_name": "Name",
+        }
+        response = self.client.post(self.profile_url, data, follow=True)
+        self.assertRedirects(response, self.profile_url)
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, "updated@example.com")
+        self.assertEqual(self.user.first_name, "Updated")
+        self.assertEqual(self.user.last_name, "Name")
+
+    def test_profile_update_shows_success_message(self):
+        """Profile update should show success message."""
+        self.client.login(username="testuser", password="testpass123")
+        data = {
+            "email": "updated@example.com",
+            "first_name": "Updated",
+            "last_name": "Name",
+        }
+        response = self.client.post(self.profile_url, data, follow=True)
+        messages = list(response.context["messages"])
+        self.assertEqual(len(messages), 1)
+        self.assertIn("updated successfully", str(messages[0]))
+
+    def test_profile_email_uniqueness_validation(self):
+        """Profile should reject email already used by another user."""
+        User.objects.create_user(
+            username="otheruser", email="taken@example.com", password="pass123"
+        )
+        self.client.login(username="testuser", password="testpass123")
+        data = {
+            "email": "taken@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+        }
+        response = self.client.post(self.profile_url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "email is already registered")
+
+    def test_profile_allows_keeping_own_email(self):
+        """User should be able to keep their own email."""
+        self.client.login(username="testuser", password="testpass123")
+        data = {
+            "email": "test@example.com",
+            "first_name": "Updated",
+            "last_name": "User",
+        }
+        response = self.client.post(self.profile_url, data, follow=True)
+        self.assertRedirects(response, self.profile_url)
+
+
+class PasswordChangeViewTests(TestCase):
+    """Tests for the password change view."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="oldpass123"
+        )
+        self.password_change_url = reverse("password_change")
+        self.password_change_done_url = reverse("password_change_done")
+
+    def test_password_change_requires_login(self):
+        """Password change page should require login."""
+        response = self.client.get(self.password_change_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response.url)
+
+    def test_password_change_loads_for_authenticated_user(self):
+        """Password change page should load for authenticated users."""
+        self.client.login(username="testuser", password="oldpass123")
+        response = self.client.get(self.password_change_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "registration/password_change_form.html")
+
+    def test_password_change_success(self):
+        """Password change should work with valid data."""
+        self.client.login(username="testuser", password="oldpass123")
+        data = {
+            "old_password": "oldpass123",
+            "new_password1": "NewSecurePass456!",
+            "new_password2": "NewSecurePass456!",
+        }
+        response = self.client.post(self.password_change_url, data, follow=True)
+        self.assertRedirects(response, self.password_change_done_url)
+
+        # Verify password was changed
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("NewSecurePass456!"))
+
+    def test_password_change_done_page(self):
+        """Password change done page should display success message."""
+        self.client.login(username="testuser", password="oldpass123")
+        response = self.client.get(self.password_change_done_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Password Changed")
+
+
+class NavigationTests(TestCase):
+    """Tests for navigation display based on auth state."""
+
+    def test_nav_shows_login_when_not_authenticated(self):
+        """Navigation should show login link when not authenticated."""
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, 'href="/login/"')
+        self.assertNotContains(response, "user-menu")
+
+    def test_nav_shows_user_menu_when_authenticated(self):
+        """Navigation should show user menu when authenticated."""
+        User.objects.create_user(username="testuser", password="testpass123")
+        self.client.login(username="testuser", password="testpass123")
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, "user-menu")
+        self.assertContains(response, 'href="/profile/"')
+
+    def test_nav_shows_initials_with_full_name(self):
+        """Avatar should show both initials when first and last name are set."""
+        User.objects.create_user(
+            username="testuser",
+            password="testpass123",
+            first_name="John",
+            last_name="Doe",
+        )
+        self.client.login(username="testuser", password="testpass123")
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, "JD")
+
+    def test_nav_shows_first_initial_with_first_name_only(self):
+        """Avatar should show first initial when only first name is set."""
+        User.objects.create_user(username="testuser", password="testpass123", first_name="John")
+        self.client.login(username="testuser", password="testpass123")
+        response = self.client.get(reverse("home"))
+        content = response.content.decode()
+        self.assertIn("user-menu__avatar", content)
+        # Should contain J but not JD
+        self.assertIn(">J<", content.replace("\n", "").replace(" ", ""))
+
+    def test_nav_shows_username_initial_with_no_name(self):
+        """Avatar should show username initial when no name is set."""
+        User.objects.create_user(username="testuser", password="testpass123")
+        self.client.login(username="testuser", password="testpass123")
+        response = self.client.get(reverse("home"))
+        content = response.content.decode()
+        self.assertIn("user-menu__avatar", content)
+        # Should contain t (first letter of testuser)
+        self.assertIn(">t<", content.replace("\n", "").replace(" ", ""))

--- a/the_flip/apps/accounts/views.py
+++ b/the_flip/apps/accounts/views.py
@@ -1,8 +1,11 @@
 from django.contrib import messages
 from django.contrib.auth import get_user_model, login
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse_lazy
+from django.views.generic import UpdateView
 
-from .forms import InvitationRegistrationForm
+from .forms import InvitationRegistrationForm, ProfileForm
 from .models import Invitation, Maintainer
 
 User = get_user_model()
@@ -48,3 +51,18 @@ def invitation_register(request, token):
         "registration/invitation_register.html",
         {"form": form, "invitation": invitation},
     )
+
+
+class ProfileUpdateView(LoginRequiredMixin, UpdateView):
+    """Allow users to update their profile information."""
+
+    form_class = ProfileForm
+    template_name = "accounts/profile.html"
+    success_url = reverse_lazy("profile")
+
+    def get_object(self):
+        return self.request.user
+
+    def form_valid(self, form):
+        messages.success(self.request, "Profile updated successfully.")
+        return super().form_valid(form)

--- a/the_flip/static/core/styles.css
+++ b/the_flip/static/core/styles.css
@@ -108,6 +108,111 @@ header nav span {
   text-decoration: underline;
 }
 
+/* ==========================================================================
+   User Menu (avatar dropdown in header)
+   Base: .user-menu
+   BEM Elements: .user-menu__avatar, .user-menu__dropdown, .user-menu__item
+   ========================================================================== */
+.user-menu {
+  position: relative;
+}
+
+.user-menu__avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: var(--color-surface);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.2s ease;
+}
+
+.user-menu__avatar:hover,
+.user-menu__avatar:focus-visible {
+  background: #1a66c0;
+}
+
+.user-menu__avatar:focus-visible {
+  outline: 2px solid var(--color-surface);
+  outline-offset: 2px;
+}
+
+.user-menu__dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: var(--space-2);
+  background: var(--color-surface);
+  border-radius: var(--radius-base);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 120px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s;
+  z-index: 100;
+}
+
+.user-menu:hover .user-menu__dropdown,
+.user-menu:focus-within .user-menu__dropdown {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.user-menu__item {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s ease;
+}
+
+.user-menu__item:hover,
+.user-menu__item:focus-visible {
+  background: var(--color-surface-muted);
+  text-decoration: none;
+}
+
+.user-menu__item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.user-menu__dropdown form {
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-menu__dropdown {
+    transition: none;
+  }
+
+  .user-menu__avatar {
+    transition: none;
+  }
+
+  .user-menu__item {
+    transition: none;
+  }
+}
+
 main {
   max-width: 960px;
   margin: 0 auto;

--- a/the_flip/urls.py
+++ b/the_flip/urls.py
@@ -21,7 +21,7 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import path, re_path
 
-from the_flip.apps.accounts.views import invitation_register
+from the_flip.apps.accounts.views import ProfileUpdateView, invitation_register
 from the_flip.apps.catalog.views import (
     MachineDetailView,
     MachineListView,
@@ -50,6 +50,22 @@ urlpatterns = [
         "register/<str:token>/",
         invitation_register,
         name="invitation-register",
+    ),
+    # Profile
+    path("profile/", ProfileUpdateView.as_view(), name="profile"),
+    path(
+        "profile/password/",
+        auth_views.PasswordChangeView.as_view(
+            template_name="registration/password_change_form.html"
+        ),
+        name="password_change",
+    ),
+    path(
+        "profile/password/done/",
+        auth_views.PasswordChangeDoneView.as_view(
+            template_name="registration/password_change_done.html"
+        ),
+        name="password_change_done",
     ),
     # Public machine pages
     path("m/", PublicMachineListView.as_view(), name="public-machine-list"),


### PR DESCRIPTION
## Summary
Enable users to manage their own information:
- Add profile page to edit email, first name, last name
- Add password change functionality for logged-in users
- Replace nav username with avatar circle showing user initials
- Add dropdown menu with Profile and Logout links (CSS-only, no JavaScript)
- Add 15 tests covering profile, password change, and navigation
- Document user-menu component in HTML_CSS.md
- Makefile improvement: kill existing dev server before starting new one

## Files Changed
- **Forms/Views**: Added ProfileForm and ProfileUpdateView
- **URLs**: Added /profile/, /profile/password/, /profile/password/done/
- **Templates**: New profile.html, password_change_form.html, password_change_done.html
- **Navigation**: Updated base.html with avatar dropdown
- **Styles**: Added user-menu component to styles.css
- **Tests**: 15 new tests in accounts/tests.py
- **Docs**: Updated HTML_CSS.md with user-menu pattern

## Test plan
- [x] Tests pass (15 new tests added)
- [x] Pre-commit hooks pass (ruff, mypy, djlint)
- [x] Manual testing: profile editing, password change, dropdown navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)