### PR TITLE
Fix CI: add missing djlint to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 
 # Code formatting and linting
 ruff==0.8.4
+djlint==1.36.4
 
 # Type checking
 mypy==1.13.0


### PR DESCRIPTION
## Summary
- `djlint` was used in CI's lint step but was never added to `requirements-dev.txt`
- This caused CI to fail with `No module named djlint` since CI run #50

## Test plan
- [ ] Verify CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)