### PR TITLE
Add Claude Code web dependencies via SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "command -v ffmpeg || (sudo apt-get update -qq && sudo apt-get install -y -qq libheif1 libheif-dev ffmpeg)"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with a SessionStart hook
- Installs libheif1, libheif-dev, and ffmpeg when Claude Code web starts a session
- These are the same packages configured in `nixpacks.toml` for Railway deployment

## Why
Claude Code on the web uses its own container environment that doesn't read `nixpacks.toml`. The SessionStart hook ensures system dependencies are available when working on this codebase in the web environment.

## Test plan
- [ ] Open repo in Claude Code on the web
- [ ] Verify `ffmpeg -version` works
- [ ] Verify `python manage.py check_ffmpeg` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)