### PR TITLE
Ignoring more files when triggering build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,26 @@ name: CI
 on:
   push:
     branches: [ main ]
+    # When updating this, also update what's ignored in railway.toml
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.vscode/**'
       - '.claude/**'
+      - '.pre-commit-config.yaml'
+      - '.env.example'
+      - '.env.vscode'
   pull_request:
     branches: [ main ]
+    # When updating this, also update what's ignored in railway.toml
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.vscode/**'
       - '.claude/**'
+      - '.pre-commit-config.yaml'
+      - '.env.example'
+      - '.env.vscode'
 
 jobs:
   test:

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,18 @@
 [build]
 builder = "NIXPACKS"
 buildCommand = "./build.sh"
+# When updating this, also update what's ignored in .github/workflows/ci.yml
+watchPatterns = [
+  "**",
+  "!**/*.md",
+  "!docs/**",
+  "!.github/**",
+  "!.claude/**",
+  "!.vscode/**",
+  "!.pre-commit-config.yaml",
+  "!.env.example",
+  "!.env.vscode"
+]
 
 [deploy]
 # startCommand intentionally omitted - configure per service:


### PR DESCRIPTION
Telling github CI and railway to not do CI and builds on more files that don't affect the runtime.