### PR TITLE
Fix infinite scroll not appending items

### DIFF
--- a/the_flip/static/core/log_infinite.js
+++ b/the_flip/static/core/log_infinite.js
@@ -44,7 +44,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (data.items) {
           const fragment = document.createElement("div");
           fragment.innerHTML = data.items;
-          fragment.childNodes.forEach((node) => {
+          Array.from(fragment.children).forEach((node) => {
             list.appendChild(node);
           });
           if (typeof applySmartDates === "function") {


### PR DESCRIPTION
## Summary
- Fixed bug where infinite scroll on log pages wasn't appending new items to the list
- The issue was that iterating over `childNodes` while calling `appendChild` caused nodes to be skipped (indices shift as nodes are moved)
- Changed to `Array.from(fragment.children)` to create a static copy before iterating

## Affected pages
- `/logs/` (global log list)
- `/logs/<slug>/` (machine-specific log)

## Test plan
- [x] Manually verified on `/logs/hokus-pokus/` with 20 entries - scrolling now loads page 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)