### PR TITLE
Add infinite scroll to problem reports and search to machine list

### DIFF
--- a/templates/catalog/machine_list.html
+++ b/templates/catalog/machine_list.html
@@ -1,18 +1,27 @@
 {% extends "base.html" %}
+{% load static %}
 {% block title %}Machines · {{ block.super }}{% endblock %}
 {% block content %}
-  <div style="display: flex;
-              justify-content: space-between;
-              align-items: center;
-              margin-bottom: 1.5rem">
-    <h2 style="margin: 0;">Machines</h2>
-    <a href="{% url 'machine-quick-create' %}" class="btn btn-primary">+ Add Machine</a>
+  <h2>Machines</h2>
+  <div class="list-header">
+    <div class="list-header__left">
+      <div class="form-field">
+        <input type="search"
+               id="machine-search"
+               placeholder="Search..."
+               class="search-input">
+      </div>
+    </div>
+    <div class="list-header__right">
+      <a href="{% url 'machine-quick-create' %}" class="btn btn-primary">+ Add Machine</a>
+    </div>
   </div>
   {% if machines %}
-    <ul class="list machine-list">
+    <ul class="list machine-list" id="machine-list">
       {% for machine in machines %}
         <li class="machine-card js-clickable-card"
             data-url="{% url 'maintainer-machine-detail' machine.slug %}"
+            data-search-text="{{ machine.display_name }} {{ machine.model.year }} {{ machine.model.manufacturer }} {{ machine.get_operational_status_display }}{% if machine.location %} {{ machine.location.name }}{% endif %}"
             tabindex="0"
             role="button"
             aria-label="View {{ machine.display_name }}">
@@ -46,4 +55,7 @@
   {% else %}
     <p>No machines yet.</p>
   {% endif %}
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{% static 'core/machine_filter.js' %}" defer></script>
 {% endblock %}

--- a/templates/maintenance/partials/problem_report_list_entry.html
+++ b/templates/maintenance/partials/problem_report_list_entry.html
@@ -1,0 +1,22 @@
+{% load core_extras %}
+<li class="machine-card js-clickable-card"
+    data-url="{% url 'problem-report-detail' report.pk %}"
+    tabindex="0"
+    role="button"
+    aria-label="View problem report for {{ report.machine.display_name }}">
+  <div class="machine-card__row">
+    <div class="machine-card__row-left">
+      <span class="machine-card__name">{{ report.machine.display_name }}</span>
+    </div>
+    <div class="machine-card__meta-group">
+      <span class="machine-card__timestamp">{{ report.created_at|smart_date }}</span>
+      <span class="badge badge-status badge-{{ report.status }}">{{ report.get_status_display }}</span>
+    </div>
+  </div>
+  <div class="machine-card__problem">
+    {% if report.problem_type != report.PROBLEM_OTHER %}
+      <span class="machine-card__problem-label">{{ report.get_problem_type_display }}:</span>
+    {% endif %}
+    {{ report.description|default:"No description provided." }}
+  </div>
+</li>

--- a/templates/maintenance/problem_report_list.html
+++ b/templates/maintenance/problem_report_list.html
@@ -1,35 +1,40 @@
 {% extends "base.html" %}
-{% load core_extras %}
+{% load static core_extras %}
 {% block title %}Problem Reports · {{ block.super }}{% endblock %}
 {% block content %}
   <h2>Problem Reports</h2>
-  {% if reports %}
-    <ul class="list machine-list problem-report-list">
-      {% for report in reports %}
-        <li class="machine-card js-clickable-card"
-            data-url="{% url 'problem-report-detail' report.pk %}"
-            tabindex="0"
-            role="button"
-            aria-label="View problem report for {{ report.machine.display_name }}">
-          <div class="machine-card__row">
-            <div class="machine-card__row-left">
-              <span class="machine-card__name">{{ report.machine.display_name }}</span>
-            </div>
-            <div class="machine-card__meta-group">
-              <span class="machine-card__timestamp">{{ report.created_at|smart_date }}</span>
-              <span class="badge badge-status badge-{{ report.status }}">{{ report.get_status_display }}</span>
-            </div>
-          </div>
-          <div class="machine-card__problem">
-            {% if report.problem_type != report.PROBLEM_OTHER %}
-              <span class="machine-card__problem-label">{{ report.get_problem_type_display }}:</span>
-            {% endif %}
-            {{ report.description|default:"No description provided." }}
-          </div>
-        </li>
-      {% endfor %}
-    </ul>
-  {% else %}
-    <p>No reports yet.</p>
-  {% endif %}
+  <div class="list-header">
+    <div class="list-header__right">
+      <form method="get" action="">
+        <div class="form-field">{{ search_form.q }}</div>
+      </form>
+    </div>
+  </div>
+  <section>
+    <div id="log-container"
+         data-fetch-url="{% url 'problem-report-list-entries' %}">
+      {% if reports %}
+        <ul class="list machine-list problem-report-list" id="log-list">
+          {% for report in reports %}
+            {% include "maintenance/partials/problem_report_list_entry.html" with report=report %}
+          {% endfor %}
+        </ul>
+        <div id="log-pagination"
+             data-next-page="{% if page_obj.has_next %}{{ page_obj.next_page_number }}{% else %}0{% endif %}"></div>
+      {% else %}
+        <p>
+          {% if search_form.q.value %}
+            No problem reports match your search.
+          {% else %}
+            No problem reports yet.
+          {% endif %}
+        </p>
+      {% endif %}
+    </div>
+    <div id="log-loading" class="hidden">Loading…</div>
+    <div id="log-sentinel"></div>
+  </section>
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{% static 'core/log_infinite.js' %}" defer></script>
 {% endblock %}

--- a/the_flip/static/core/machine_filter.js
+++ b/the_flip/static/core/machine_filter.js
@@ -1,0 +1,22 @@
+/**
+ * Client-side filtering for the machine list.
+ * Filters machines instantly as the user types.
+ */
+(function () {
+  const searchInput = document.getElementById("machine-search");
+  const machineList = document.getElementById("machine-list");
+
+  if (!searchInput || !machineList) return;
+
+  const items = machineList.querySelectorAll("li[data-search-text]");
+
+  searchInput.addEventListener("input", function () {
+    const query = this.value.toLowerCase().trim();
+
+    items.forEach((item) => {
+      const searchText = item.dataset.searchText.toLowerCase();
+      const matches = !query || searchText.includes(query);
+      item.classList.toggle("hidden", !matches);
+    });
+  });
+})();

--- a/the_flip/urls.py
+++ b/the_flip/urls.py
@@ -96,6 +96,11 @@ urlpatterns = [
         name="problem-report-list",
     ),
     path(
+        "problem-reports/entries/",
+        maintenance_views.ProblemReportListPartialView.as_view(),
+        name="problem-report-list-entries",
+    ),
+    path(
         "problem-reports/<int:pk>/",
         maintenance_views.ProblemReportDetailView.as_view(),
         name="problem-report-detail",


### PR DESCRIPTION
- Add infinite scrolling and search to /problem-reports/ , instead of displaying every damn problem report in the system.
- Add instant client-side filtering to /machines/ page