### PR TITLE
Better markdown rendering in lists

### DIFF
--- a/templates/maintenance/partials/log_entry.html
+++ b/templates/maintenance/partials/log_entry.html
@@ -11,7 +11,7 @@
         <span>:</span>
       {% endif %}
     </div>
-    <div class="log-entry-text markdown-content">{{ entry.text|render_markdown }}</div>
+    <div class="log-entry-text markdown-content markdown-content--compact">{{ entry.text|render_markdown }}</div>
     {% if entry.media.all %}
       <div class="log-entry-media">
         {% for media in entry.media.all %}

--- a/templates/maintenance/partials/log_list_entry.html
+++ b/templates/maintenance/partials/log_list_entry.html
@@ -17,5 +17,5 @@
       {% endif %}
     </div>
   </div>
-  <div class="machine-card__problem markdown-content">{{ entry.text|render_markdown }}</div>
+  <div class="machine-card__problem markdown-content markdown-content--compact">{{ entry.text|render_markdown }}</div>
 </li>

--- a/templates/maintenance/partials/timeline_entry.html
+++ b/templates/maintenance/partials/timeline_entry.html
@@ -17,7 +17,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="machine-card__problem markdown-content">{{ entry.text|render_markdown }}</div>
+    <div class="machine-card__problem markdown-content markdown-content--compact">{{ entry.text|render_markdown }}</div>
     {% if entry.media.all %}
       <div class="machine-card__row">
         <div class="machine-card__row-left">

--- a/the_flip/static/core/styles.css
+++ b/the_flip/static/core/styles.css
@@ -617,7 +617,7 @@ input[type="radio"] {
 .log-entry-text {
   margin-top: var(--space-2);
   font-size: 1rem;
-  white-space: pre-wrap;
+  white-space: normal;
 }
 
 .log-entry-media img {
@@ -853,24 +853,22 @@ input[type="radio"] {
   margin-top: 0;
 }
 
-/* Compact markdown in truncated/card contexts */
-.machine-card__problem.markdown-content p,
-.machine-card__problem.markdown-content ul,
-.machine-card__problem.markdown-content ol {
-  margin: 0;
-  display: inline;
+.markdown-content--compact p,
+.markdown-content--compact ul,
+.markdown-content--compact ol {
+  margin: 0 0 var(--space-2) 0;
 }
 
-.machine-card__problem.markdown-content li {
-  display: inline;
+.markdown-content--compact li {
+  margin-bottom: 0;
 }
 
-.machine-card__problem.markdown-content li::before {
-  content: " • ";
-}
-
-.machine-card__problem.markdown-content li:first-child::before {
-  content: "";
+.machine-card__problem.markdown-content {
+  display: block;
+  -webkit-box-orient: unset;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  overflow: visible;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
 - Refactored markdown CSS to use a base .markdown-content plus a compact modifier for tighter list spacing in summary views.
 - Applied the compact modifier to log entry, log list, and timeline templates instead of bespoke overrides.
 - Removed redundant per-component markdown rules and added a markdown-specific override to disable card text clamping so /logs/ lists render block items correctly.