### PR TITLE
Add pre-push hook to run Django tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Pre-commit hooks configuration
-# Install with: pre-commit install
+# Install with: pre-commit install && pre-commit install --hook-type pre-push
 # Run manually: pre-commit run --all-files
 # See https://pre-commit.com for more information
 
@@ -72,3 +72,12 @@ repos:
         language: system
         types: [html]
         args: [--reformat, --quiet]
+
+      # Run Django tests before push
+      - id: django-tests
+        name: django-tests
+        entry: env DJANGO_SETTINGS_MODULE=the_flip.settings.test .venv/bin/python manage.py test --keepdb
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]


### PR DESCRIPTION
## Summary
- Adds a pre-push hook that runs the Django test suite before each push
- Tests are run with `--keepdb` for speed
- Catches test failures locally before they reach CI

## Setup
After pulling this change, run:
```bash
pre-commit install --hook-type pre-push
```

(The install instructions in the config file have been updated to include this.)

## Test plan
- [x] Verified pre-push hook runs tests successfully
- [x] Verified tests run on `git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)