### PR TITLE
Fix Constance settings crash in production

### DIFF
--- a/the_flip/settings/base.py
+++ b/the_flip/settings/base.py
@@ -134,7 +134,7 @@ DISCORD_BOT_LOG_LEVEL = config("DISCORD_BOT_LOG_LEVEL", default=None)
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 
 CONSTANCE_CONFIG = {
-    "PARTS_ENABLED": (True, "Enable the parts request feature", bool),
+    "PARTS_ENABLED": (False, "Enable the parts request feature", bool),
     # Discord Bot settings (inbound - listening to Discord messages)
     "DISCORD_BOT_ENABLED": (False, "Master switch for Discord bot", bool),
     "DISCORD_BOT_TOKEN": ("", "Discord bot token (keep secret!)", str),

--- a/the_flip/settings/prod_base.py
+++ b/the_flip/settings/prod_base.py
@@ -88,8 +88,3 @@ else:
             conn_health_checks=True,
         )
     }
-
-# Feature flags - disabled by default in production (enable via admin)
-CONSTANCE_CONFIG = {
-    "PARTS_ENABLED": (False, "Enable the parts request feature", bool),
-}


### PR DESCRIPTION
## Summary

Fixes 500 error on `/admin/constance/config/` in production.

Production was overriding `CONSTANCE_CONFIG` with only `PARTS_ENABLED`, but `CONSTANCE_CONFIG_FIELDSETS` in base.py still referenced Discord webhook fields that weren't defined, causing:

```
ValueError: CONSTANCE_CONFIG_FIELDSETS contains field(s) that does not exist(s): 
DISCORD_WEBHOOK_URL, DISCORD_WEBHOOKS_ENABLED, ...
```

**Fix:** Remove the prod override and set `PARTS_ENABLED` default to `False` in base.py. All Constance settings now defined in one place.

## Test plan

- [ ] Deploy and verify `/admin/constance/config/` loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)