### PR TITLE
Fix client IP detection behind Railway proxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,9 @@ linkify-it-py==2.0.3
 # Audit Logging
 django-simple-history==3.10.1
 
+# Client IP Detection (behind proxies)
+django-ipware==7.0.1
+
 # Discord Bot
 discord.py==2.4.0
 httpx==0.28.1

--- a/the_flip/apps/core/ip.py
+++ b/the_flip/apps/core/ip.py
@@ -1,0 +1,20 @@
+"""Client IP address utilities."""
+
+from __future__ import annotations
+
+from django.http import HttpRequest
+from ipware import get_client_ip
+
+
+def get_real_ip(request: HttpRequest) -> str | None:
+    """
+    Extract the real client IP address from a request.
+
+    Uses django-ipware to correctly handle proxied requests (e.g., behind
+    Railway, Cloudflare, or other reverse proxies) by parsing X-Forwarded-For
+    and related headers.
+
+    Returns None if the IP cannot be determined.
+    """
+    ip, _ = get_client_ip(request)
+    return ip

--- a/the_flip/apps/maintenance/views.py
+++ b/the_flip/apps/maintenance/views.py
@@ -36,6 +36,7 @@ from PIL import Image, ImageOps
 
 from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.catalog.models import Location, MachineInstance
+from the_flip.apps.core.ip import get_real_ip
 from the_flip.apps.core.mixins import (
     CanAccessMaintainerPortalMixin,
     MediaUploadMixin,
@@ -447,7 +448,7 @@ class PublicProblemReportCreateView(FormView):
 
     def post(self, request, *args, **kwargs):
         # Check rate limiting
-        ip_address = request.META.get("REMOTE_ADDR")
+        ip_address = get_real_ip(request)
         if ip_address and not self._check_rate_limit(ip_address):
             messages.error(request, "Too many reports submitted recently. Please try again later.")
             return redirect("public-problem-report-create", slug=self.machine.slug)
@@ -463,7 +464,7 @@ class PublicProblemReportCreateView(FormView):
     def form_valid(self, form):
         report = form.save(commit=False)
         report.machine = self.machine
-        report.ip_address = self.request.META.get("REMOTE_ADDR")
+        report.ip_address = get_real_ip(self.request)
         report.device_info = self.request.META.get("HTTP_USER_AGENT", "")[:200]
         if self.request.user.is_authenticated:
             report.reported_by_user = self.request.user
@@ -518,7 +519,7 @@ class ProblemReportCreateView(CanAccessMaintainerPortalMixin, FormView):
 
         report = form.save(commit=False)
         report.machine = machine
-        report.ip_address = self.request.META.get("REMOTE_ADDR")
+        report.ip_address = get_real_ip(self.request)
         report.device_info = self.request.META.get("HTTP_USER_AGENT", "")[:200]
         if self.request.user.is_authenticated:
             report.reported_by_user = self.request.user

--- a/the_flip/middleware.py
+++ b/the_flip/middleware.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from whitenoise.middleware import WhiteNoiseMiddleware
 
+from the_flip.apps.core.ip import get_real_ip
 from the_flip.logging import bind_log_context, reset_log_context
 
 
@@ -35,7 +36,7 @@ class RequestContextMiddleware:
             method=request.method,
             user_id=user_id,
             username=username,
-            remote_ip=request.META.get("REMOTE_ADDR"),
+            remote_ip=get_real_ip(request),
         )
         request.request_id = request_id  # type: ignore[attr-defined]
         try:


### PR DESCRIPTION
## Summary
- Use `django-ipware` to extract the real client IP from `X-Forwarded-For` headers
- Previously, `REMOTE_ADDR` was used directly, which returns the proxy's IP when running behind Railway
- This broke rate limiting (all visitors shared one "IP") and made audit logs point to the proxy

## Changes
- Add `django-ipware==7.0.1` dependency
- Create `core/ip.py` utility with `get_real_ip()` wrapper
- Update middleware and views to use the new utility

## Test plan
- [x] All 351 tests pass
- [x] Quality checks pass
- [x] Deploy to Railway and verify real client IPs appear in logs/problem reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)