### PR TITLE
Refactor model choices to TextChoices pattern

### DIFF
--- a/docs/Models.md
+++ b/docs/Models.md
@@ -18,7 +18,7 @@ We use a mixin (not a base class) to discourage adding unrelated behavior.
 
 ## Choice Fields
 
-**Target pattern** (migration pending [#131](https://github.com/deanmoses/the_flip/issues/131)):
+Use Django's `TextChoices` for fields with fixed options:
 
 ```python
 class ProblemReport(TimeStampedMixin):
@@ -33,7 +33,7 @@ if report.status == ProblemReport.Status.OPEN:
     ...
 ```
 
-TextChoices provides type safety and IDE autocomplete. Current code uses class constants (`STATUS_OPEN = "open"`) which works but is less explicit.
+TextChoices provides type safety and IDE autocomplete.
 
 ## Field Nullability
 
@@ -76,11 +76,11 @@ Encapsulate reusable queries in QuerySet classes instead of repeating filter log
 class PartRequestQuerySet(models.QuerySet):
     def active(self):
         """Return part requests that are not cancelled."""
-        return self.exclude(status=PartRequest.STATUS_CANCELLED)
+        return self.exclude(status=PartRequest.Status.CANCELLED)
 
     def pending(self):
         """Return part requests that are requested or ordered."""
-        return self.filter(status__in=[PartRequest.STATUS_REQUESTED, PartRequest.STATUS_ORDERED])
+        return self.filter(status__in=[PartRequest.Status.REQUESTED, PartRequest.Status.ORDERED])
 
 class PartRequest(TimeStampedMixin):
     objects = PartRequestQuerySet.as_manager()

--- a/templates/catalog/machine_edit.html
+++ b/templates/catalog/machine_edit.html
@@ -27,16 +27,16 @@
     <div class="dropdown">
       <button type="button"
               id="status-pill"
-              class="pill {% if object.operational_status == 'good' %}pill--status-good{% elif object.operational_status == 'fixing' %}pill--status-fixing{% elif object.operational_status == 'broken' %}pill--status-broken{% else %}pill--neutral{% endif %}"
+              class="pill {% if object.operational_status == object.OperationalStatus.GOOD %}pill--status-good{% elif object.operational_status == object.OperationalStatus.FIXING %}pill--status-fixing{% elif object.operational_status == object.OperationalStatus.BROKEN %}pill--status-broken{% else %}pill--neutral{% endif %}"
               aria-haspopup="true"
               aria-expanded="false"
               onclick="toggleDropdown(this)">
-        <i class="fa-solid {% if object.operational_status == 'fixing' %}fa-wrench{% elif object.operational_status == 'good' %}fa-check{% elif object.operational_status == 'broken' %}fa-circle-xmark{% else %}fa-circle-question{% endif %} meta status-icon"></i>
+        <i class="fa-solid {% if object.operational_status == object.OperationalStatus.FIXING %}fa-wrench{% elif object.operational_status == object.OperationalStatus.GOOD %}fa-check{% elif object.operational_status == object.OperationalStatus.BROKEN %}fa-circle-xmark{% else %}fa-circle-question{% endif %} meta status-icon"></i>
         <span class="status-label">{{ object.get_operational_status_display }}</span>
         <i class="fa-solid fa-caret-down meta"></i>
       </button>
       <div class="dropdown__menu dropdown__menu--left hidden">
-        {% for value, label in object.STATUS_CHOICES %}
+        {% for value, label in object.OperationalStatus.choices %}
           <button type="button"
                   class="dropdown__item"
                   data-field="operational_status"

--- a/templates/catalog/machine_feed_base.html
+++ b/templates/catalog/machine_feed_base.html
@@ -18,17 +18,17 @@
          data-update-url="{% url 'machine-inline-update' machine.slug %}">
       <div class="dropdown">
         <button type="button"
-                class="btn btn--dropdown status-btn {% if machine.operational_status == 'good' %}btn--status-good{% elif machine.operational_status == 'fixing' %}btn--status-fixing{% elif machine.operational_status == 'broken' %}btn--status-broken{% else %}btn--secondary{% endif %}"
+                class="btn btn--dropdown status-btn {% if machine.operational_status == machine.OperationalStatus.GOOD %}btn--status-good{% elif machine.operational_status == machine.OperationalStatus.FIXING %}btn--status-fixing{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}btn--status-broken{% else %}btn--secondary{% endif %}"
                 aria-haspopup="true"
                 aria-expanded="false"
                 aria-label="Change status"
                 title="Status: {{ machine.get_operational_status_display }}"
                 onclick="toggleDropdown(this)">
-          <i class="fa-solid {% if machine.operational_status == 'fixing' %}fa-wrench{% elif machine.operational_status == 'good' %}fa-check{% elif machine.operational_status == 'broken' %}fa-circle-xmark{% else %}fa-circle-question{% endif %} status-icon"></i>
+          <i class="fa-solid {% if machine.operational_status == machine.OperationalStatus.FIXING %}fa-wrench{% elif machine.operational_status == machine.OperationalStatus.GOOD %}fa-check{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}fa-circle-xmark{% else %}fa-circle-question{% endif %} status-icon"></i>
           <i class="fa-solid fa-caret-down btn__caret"></i>
         </button>
         <div class="dropdown__menu dropdown__menu--left hidden">
-          {% for value, label in machine.STATUS_CHOICES %}
+          {% for value, label in machine.OperationalStatus.choices %}
             <button type="button"
                     class="dropdown__item{% if value == machine.operational_status %} dropdown__item--selected{% endif %}"
                     data-field="operational_status"
@@ -104,16 +104,16 @@
             <div class="dropdown">
               <button type="button"
                       id="status-pill"
-                      class="pill {% if machine.operational_status == 'good' %}pill--status-good{% elif machine.operational_status == 'fixing' %}pill--status-fixing{% elif machine.operational_status == 'broken' %}pill--status-broken{% else %}pill--neutral{% endif %}"
+                      class="pill {% if machine.operational_status == machine.OperationalStatus.GOOD %}pill--status-good{% elif machine.operational_status == machine.OperationalStatus.FIXING %}pill--status-fixing{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}pill--status-broken{% else %}pill--neutral{% endif %}"
                       aria-haspopup="true"
                       aria-expanded="false"
                       onclick="toggleDropdown(this)">
-                <i class="fa-solid {% if machine.operational_status == 'fixing' %}fa-wrench{% elif machine.operational_status == 'good' %}fa-check{% elif machine.operational_status == 'broken' %}fa-circle-xmark{% else %}fa-circle-question{% endif %} meta status-icon"></i>
+                <i class="fa-solid {% if machine.operational_status == machine.OperationalStatus.FIXING %}fa-wrench{% elif machine.operational_status == machine.OperationalStatus.GOOD %}fa-check{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}fa-circle-xmark{% else %}fa-circle-question{% endif %} meta status-icon"></i>
                 <span class="status-label">{{ machine.get_operational_status_display }}</span>
                 <i class="fa-solid fa-caret-down meta"></i>
               </button>
               <div class="dropdown__menu dropdown__menu--left hidden">
-                {% for value, label in machine.STATUS_CHOICES %}
+                {% for value, label in machine.OperationalStatus.choices %}
                   <button type="button"
                           class="dropdown__item{% if value == machine.operational_status %} dropdown__item--selected{% endif %}"
                           data-field="operational_status"

--- a/templates/catalog/partials/machine_list_card.html
+++ b/templates/catalog/partials/machine_list_card.html
@@ -5,12 +5,12 @@
      class="machine-card__link">
     <span class="machine-card__title">{{ machine.display_name }}</span>
     <div class="machine-card__pills">
-      <span class="pill {% if machine.operational_status == 'good' %}pill--status-good{% elif machine.operational_status == 'fixing' %}pill--status-fixing{% elif machine.operational_status == 'broken' %}pill--status-broken{% else %}pill--neutral{% endif %}">
-        {% if machine.operational_status == 'fixing' %}
+      <span class="pill {% if machine.operational_status == machine.OperationalStatus.GOOD %}pill--status-good{% elif machine.operational_status == machine.OperationalStatus.FIXING %}pill--status-fixing{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}pill--status-broken{% else %}pill--neutral{% endif %}">
+        {% if machine.operational_status == machine.OperationalStatus.FIXING %}
           <i class="fa-solid fa-wrench meta"></i>
-        {% elif machine.operational_status == 'good' %}
+        {% elif machine.operational_status == machine.OperationalStatus.GOOD %}
           <i class="fa-solid fa-check meta"></i>
-        {% elif machine.operational_status == 'broken' %}
+        {% elif machine.operational_status == machine.OperationalStatus.BROKEN %}
           <i class="fa-solid fa-circle-xmark meta"></i>
         {% else %}
           <i class="fa-solid fa-circle-question meta"></i>

--- a/templates/components/machine_sidebar_card.html
+++ b/templates/components/machine_sidebar_card.html
@@ -9,8 +9,8 @@
     {% if machine.model.year %}{{ machine.model.year }}{% endif %}
   </p>
   <div class="sidebar-card__badges">
-    <span class="pill {% if machine.operational_status == 'good' %}pill--status-good{% elif machine.operational_status == 'fixing' %}pill--status-fixing{% elif machine.operational_status == 'broken' %}pill--status-broken{% else %}pill--neutral{% endif %}">
-      <i class="fa-solid {% if machine.operational_status == 'fixing' %}fa-wrench{% elif machine.operational_status == 'good' %}fa-check{% elif machine.operational_status == 'broken' %}fa-circle-xmark{% else %}fa-circle-question{% endif %} meta"></i>
+    <span class="pill {% if machine.operational_status == machine.OperationalStatus.GOOD %}pill--status-good{% elif machine.operational_status == machine.OperationalStatus.FIXING %}pill--status-fixing{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}pill--status-broken{% else %}pill--neutral{% endif %}">
+      <i class="fa-solid {% if machine.operational_status == machine.OperationalStatus.FIXING %}fa-wrench{% elif machine.operational_status == machine.OperationalStatus.GOOD %}fa-check{% elif machine.operational_status == machine.OperationalStatus.BROKEN %}fa-circle-xmark{% else %}fa-circle-question{% endif %} meta"></i>
       {{ machine.get_operational_status_display }}
     </span>
     {% if machine.location %}

--- a/templates/core/partials/media_card_editable.html
+++ b/templates/core/partials/media_card_editable.html
@@ -18,13 +18,13 @@
     {% if media_items %}
       {% for media in media_items %}
         <div class="media-grid__item" data-media-id="{{ media.id }}">
-          {% if media.media_type == 'video' %}
-            {% if media.transcode_status == 'ready' and media.transcoded_file %}
+          {% if media.media_type == media.MediaType.VIDEO %}
+            {% if media.transcode_status == media.TranscodeStatus.READY and media.transcoded_file %}
               <video controls poster="{{ media.poster_file.url }}">
                 <source src="{{ media.transcoded_file.url }}" type="video/mp4">
                 Your browser doesn't support video playback.
               </video>
-            {% elif media.transcode_status == 'processing' or media.transcode_status == 'pending' %}
+            {% elif media.transcode_status == media.TranscodeStatus.PROCESSING or media.transcode_status == media.TranscodeStatus.PENDING %}
               <div class="media-grid__status"
                    data-media-poll-id="{{ media.id }}"
                    data-media-poll-model="{{ model_name|default:'LogEntryMedia' }}">Processing video...</div>

--- a/templates/core/partials/media_grid_readonly.html
+++ b/templates/core/partials/media_grid_readonly.html
@@ -7,10 +7,10 @@
     <div class="media-grid">
       {% for media in media_items %}
         <div class="media-grid__item">
-          {% if media.media_type == 'video' %}
-            {% if media.transcode_status == 'ready' and media.poster_file %}
+          {% if media.media_type == media.MediaType.VIDEO %}
+            {% if media.transcode_status == media.TranscodeStatus.READY and media.poster_file %}
               <img src="{{ media.poster_file.url }}" alt="Video poster">
-            {% elif media.transcode_status == 'processing' or media.transcode_status == 'pending' %}
+            {% elif media.transcode_status == media.TranscodeStatus.PROCESSING or media.transcode_status == media.TranscodeStatus.PENDING %}
               <div class="media-grid__status"
                    data-media-poll-id="{{ media.id }}"
                    data-media-poll-model="{{ model_name|default:'LogEntryMedia' }}">Processing video...</div>

--- a/templates/maintenance/partials/problem_report_entry.html
+++ b/templates/maintenance/partials/problem_report_entry.html
@@ -6,7 +6,7 @@
     <div class="timeline__header">
       <div class="flex items-center stack-tight">
         <span class="timeline__title timeline__title--problem">Problem</span>
-        <span class="badge {% if entry.status == 'open' %}badge--warning{% else %}badge--success{% endif %}">
+        <span class="badge {% if entry.status == entry.Status.OPEN %}badge--warning{% else %}badge--success{% endif %}">
           {{ entry.get_status_display }}
         </span>
       </div>

--- a/templates/maintenance/partials/problem_report_list_entry.html
+++ b/templates/maintenance/partials/problem_report_list_entry.html
@@ -15,14 +15,14 @@
       </div>
     </div>
     <div class="flip-card__main">
-      {% if report.problem_type != report.PROBLEM_OTHER %}
+      {% if report.problem_type != report.ProblemType.OTHER %}
         <p>
           <strong>{{ report.get_problem_type_display }}</strong>
         </p>
       {% endif %}
       {% if report.description %}
         <div class="markdown-content markdown-content--compact">{{ report.description|render_markdown }}</div>
-      {% elif report.problem_type == report.PROBLEM_OTHER %}
+      {% elif report.problem_type == report.ProblemType.OTHER %}
         <p class="text-muted">No description provided.</p>
       {% endif %}
     </div>

--- a/templates/maintenance/problem_report_detail.html
+++ b/templates/maintenance/problem_report_detail.html
@@ -8,7 +8,7 @@
   <span><i class="fa-solid fa-bug"></i> #{{ report.pk }}</span>
 {% endblock %}
 {% block mobile_actions %}
-  {% if report.status == report.STATUS_OPEN %}
+  {% if report.status == report.Status.OPEN %}
     <form method="post">
       {% csrf_token %}
       <button type="submit" class="btn btn--log btn--full">
@@ -33,15 +33,15 @@
     <i class="fa-solid fa-bug"></i> #{{ report.pk }}
   </div>
   <div class="flex flex-wrap stack-tight space-above-sm">
-    <span class="pill {% if report.status == report.STATUS_OPEN %}pill--status-broken{% else %}pill--status-good{% endif %}">
-      {% if report.status == report.STATUS_OPEN %}
+    <span class="pill {% if report.status == report.Status.OPEN %}pill--status-broken{% else %}pill--status-good{% endif %}">
+      {% if report.status == report.Status.OPEN %}
         <i class="fa-solid fa-circle-exclamation meta"></i>
       {% else %}
         <i class="fa-solid fa-check meta"></i>
       {% endif %}
       {{ report.get_status_display }}
     </span>
-    {% if report.problem_type != report.PROBLEM_OTHER %}
+    {% if report.problem_type != report.ProblemType.OTHER %}
       <span class="pill pill--neutral">{{ report.get_problem_type_display }}</span>
     {% endif %}
   </div>
@@ -51,7 +51,7 @@
 {% include "components/machine_sidebar_card.html" with editable=True %}
 {% endsidebar_section %}
 {% sidebar_section %}
-{% if report.status == report.STATUS_OPEN %}
+{% if report.status == report.Status.OPEN %}
   <form method="post">
     {% csrf_token %}
     <button type="submit" class="btn btn--log btn--full">

--- a/templates/parts/part_request_detail.html
+++ b/templates/parts/part_request_detail.html
@@ -23,7 +23,7 @@
         <i class="fa-solid fa-caret-down meta"></i>
       </button>
       <div class="dropdown__menu dropdown__menu--left hidden">
-        {% for value, label in part_request.STATUS_CHOICES %}
+        {% for value, label in part_request.Status.choices %}
           <button type="button"
                   class="dropdown__item{% if value == part_request.status %} dropdown__item--selected{% endif %}"
                   data-value="{{ value }}"

--- a/the_flip/apps/catalog/models.py
+++ b/the_flip/apps/catalog/models.py
@@ -40,14 +40,10 @@ class Location(models.Model):
 class MachineModel(TimeStampedMixin):
     """Represents a pinball machine model."""
 
-    ERA_PM = "PM"
-    ERA_EM = "EM"
-    ERA_SS = "SS"
-    ERA_CHOICES = [
-        (ERA_PM, "Pure Mechanical"),
-        (ERA_EM, "Electromechanical"),
-        (ERA_SS, "Solid State"),
-    ]
+    class Era(models.TextChoices):
+        PM = "PM", "Pure Mechanical"
+        EM = "EM", "Electromechanical"
+        SS = "SS", "Solid State"
 
     name = models.CharField(
         max_length=200, unique=True, help_text="Official name of the pinball machine model"
@@ -66,7 +62,7 @@ class MachineModel(TimeStampedMixin):
     )
     year = models.PositiveIntegerField(null=True, blank=True, help_text="Year of manufacture")
     era = models.CharField(
-        max_length=2, choices=ERA_CHOICES, help_text="Technology era of the machine"
+        max_length=2, choices=Era.choices, help_text="Technology era of the machine"
     )
     system = models.CharField(
         max_length=100, blank=True, help_text="Electronic system type (e.g., WPC-95, System 11)"
@@ -168,23 +164,23 @@ class MachineInstanceQuerySet(models.QuerySet):
         Includes machines with active operational statuses.
         """
         return self.select_related("model").filter(
-            operational_status__in=["good", "fixing", "broken", "unknown"]
+            operational_status__in=[
+                MachineInstance.OperationalStatus.GOOD,
+                MachineInstance.OperationalStatus.FIXING,
+                MachineInstance.OperationalStatus.BROKEN,
+                MachineInstance.OperationalStatus.UNKNOWN,
+            ]
         )
 
 
 class MachineInstance(TimeStampedMixin):
     """Physical machine owned by the museum."""
 
-    STATUS_GOOD = "good"
-    STATUS_UNKNOWN = "unknown"
-    STATUS_FIXING = "fixing"
-    STATUS_BROKEN = "broken"
-    STATUS_CHOICES = [
-        (STATUS_GOOD, "Good"),
-        (STATUS_FIXING, "Fixing"),
-        (STATUS_BROKEN, "Broken"),
-        (STATUS_UNKNOWN, "Unknown"),
-    ]
+    class OperationalStatus(models.TextChoices):
+        GOOD = "good", "Good"
+        FIXING = "fixing", "Fixing"
+        BROKEN = "broken", "Broken"
+        UNKNOWN = "unknown", "Unknown"
 
     model = models.ForeignKey(
         MachineModel,
@@ -223,8 +219,8 @@ class MachineInstance(TimeStampedMixin):
     )
     operational_status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=STATUS_UNKNOWN,
+        choices=OperationalStatus.choices,
+        default=OperationalStatus.UNKNOWN,
         verbose_name="Status",
         help_text="Current working condition",
     )

--- a/the_flip/apps/catalog/signals.py
+++ b/the_flip/apps/catalog/signals.py
@@ -47,7 +47,10 @@ def create_auto_log_entries(sender, instance, created, **kwargs):
     # Check for status change
     original_status = getattr(instance, "_original_operational_status", None)
     if original_status and original_status != instance.operational_status:
-        old_display = dict(MachineInstance.STATUS_CHOICES).get(original_status, original_status)
+        try:
+            old_display = MachineInstance.OperationalStatus(original_status).label
+        except ValueError:
+            old_display = original_status
         new_display = instance.get_operational_status_display()
         log_entry = LogEntry.objects.create(
             machine=instance,

--- a/the_flip/apps/catalog/tests.py
+++ b/the_flip/apps/catalog/tests.py
@@ -80,7 +80,7 @@ class MachineQuickCreateViewTests(AccessControlTestCase):
             name="Existing Machine",
             manufacturer="Williams",
             year=1995,
-            era=MachineModel.ERA_SS,
+            era=MachineModel.Era.SS,
         )
 
         # Create maintainer user
@@ -153,7 +153,7 @@ class MachineQuickCreateViewTests(AccessControlTestCase):
 
         # Verify the new instance was created correctly
         new_instance = MachineInstance.objects.get(model=new_model)
-        self.assertEqual(new_instance.operational_status, MachineInstance.STATUS_UNKNOWN)
+        self.assertEqual(new_instance.operational_status, MachineInstance.OperationalStatus.UNKNOWN)
         self.assertIsNone(new_instance.location)
         self.assertEqual(new_instance.created_by, self.maintainer_user)
         self.assertEqual(new_instance.updated_by, self.maintainer_user)
@@ -208,7 +208,7 @@ class MachineQuickCreateViewTests(AccessControlTestCase):
         # Verify the instance was created with the existing model
         new_instance = MachineInstance.objects.get(name_override="Machine #2")
         self.assertEqual(new_instance.model, self.existing_model)
-        self.assertEqual(new_instance.operational_status, MachineInstance.STATUS_UNKNOWN)
+        self.assertEqual(new_instance.operational_status, MachineInstance.OperationalStatus.UNKNOWN)
         self.assertIsNone(new_instance.location)
 
     def test_validation_error_no_model_or_model_name(self):
@@ -421,7 +421,7 @@ class MachineInlineUpdateViewTests(TestCase):
         # Get the Maintainer profile (created automatically for staff users)
         maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
-        self.machine.operational_status = MachineInstance.STATUS_GOOD
+        self.machine.operational_status = MachineInstance.OperationalStatus.GOOD
         self.machine._skip_auto_log = True
         self.machine.save()
 
@@ -439,7 +439,7 @@ class MachineInlineUpdateViewTests(TestCase):
         # Ensure no Maintainer profile exists
         Maintainer.objects.filter(user=self.maintainer_user).delete()
 
-        self.machine.operational_status = MachineInstance.STATUS_GOOD
+        self.machine.operational_status = MachineInstance.OperationalStatus.GOOD
         self.machine._skip_auto_log = True
         self.machine.save()
 

--- a/the_flip/apps/catalog/views_inline.py
+++ b/the_flip/apps/catalog/views_inline.py
@@ -19,7 +19,7 @@ class MachineInlineUpdateView(CanAccessMaintainerPortalMixin, View):
 
         if action == "update_status":
             status = request.POST.get("operational_status")
-            if status in dict(MachineInstance.STATUS_CHOICES):
+            if status in MachineInstance.OperationalStatus.values:
                 if machine.operational_status == status:
                     return JsonResponse({"status": "noop"})
                 machine.operational_status = status

--- a/the_flip/apps/core/mixins.py
+++ b/the_flip/apps/core/mixins.py
@@ -107,9 +107,9 @@ class MediaUploadMixin:
 
         create_kwargs: dict[str, Any] = {
             parent_field_name: parent,
-            "media_type": media_model.TYPE_VIDEO if is_video else media_model.TYPE_PHOTO,
+            "media_type": media_model.MediaType.VIDEO if is_video else media_model.MediaType.PHOTO,
             "file": upload,
-            "transcode_status": media_model.STATUS_PENDING if is_video else "",
+            "transcode_status": media_model.TranscodeStatus.PENDING if is_video else "",
         }
 
         media = media_model.objects.create(**create_kwargs)

--- a/the_flip/apps/core/models.py
+++ b/the_flip/apps/core/models.py
@@ -154,36 +154,26 @@ class AbstractMedia(TimeStampedMixin):
     # Subclasses must define this to indicate which FK field points to the parent
     parent_field_name: ClassVar[str]
 
-    # Media type constants
-    TYPE_PHOTO = "photo"
-    TYPE_VIDEO = "video"
-    MEDIA_CHOICES = [
-        (TYPE_PHOTO, "Photo"),
-        (TYPE_VIDEO, "Video"),
-    ]
+    class MediaType(models.TextChoices):
+        PHOTO = "photo", "Photo"
+        VIDEO = "video", "Video"
 
-    # Transcode status constants
-    STATUS_PENDING = "pending"
-    STATUS_PROCESSING = "processing"
-    STATUS_READY = "ready"
-    STATUS_FAILED = "failed"
-    TRANSCODE_STATUS_CHOICES = [
-        (STATUS_PENDING, "Pending"),
-        (STATUS_PROCESSING, "Processing"),
-        (STATUS_READY, "Ready"),
-        (STATUS_FAILED, "Failed"),
-    ]
+    class TranscodeStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        PROCESSING = "processing", "Processing"
+        READY = "ready", "Ready"
+        FAILED = "failed", "Failed"
 
-    media_type = models.CharField(max_length=20, choices=MEDIA_CHOICES)
+    media_type = models.CharField(max_length=20, choices=MediaType.choices)
     file = models.FileField()  # upload_to set by subclass
     thumbnail_file = models.FileField(blank=True)
     transcoded_file = models.FileField(blank=True, null=True)
     poster_file = models.ImageField(blank=True, null=True)
     transcode_status = models.CharField(
         max_length=20,
-        choices=TRANSCODE_STATUS_CHOICES,
+        choices=TranscodeStatus.choices,
         blank=True,
-        default=STATUS_PENDING,
+        default=TranscodeStatus.PENDING,
     )
     duration = models.IntegerField(null=True, blank=True, help_text="Duration in seconds")
     display_order = models.PositiveIntegerField(null=True, blank=True)
@@ -194,7 +184,7 @@ class AbstractMedia(TimeStampedMixin):
 
     def save(self, *args, **kwargs):
         """Process photo uploads: generate thumbnail and resize for web."""
-        if self.media_type == self.TYPE_PHOTO and self.file:
+        if self.media_type == self.MediaType.PHOTO and self.file:
             from django.core.files.uploadedfile import UploadedFile as DjangoUploadedFile
 
             is_fresh_upload = hasattr(self.file, "file") and isinstance(

--- a/the_flip/apps/core/tasks.py
+++ b/the_flip/apps/core/tasks.py
@@ -113,7 +113,7 @@ def transcode_video_job(
         logger.error("Transcode job %s (%s) aborted: media not found", media_id, model_name)
         return
 
-    if media.media_type != media_model.TYPE_VIDEO:
+    if media.media_type != media_model.MediaType.VIDEO:
         logger.info("Transcode skipped for non-video media %s", media_id)
         return
 
@@ -122,13 +122,13 @@ def transcode_video_job(
         web_service_url, upload_token = _get_transcoding_config()
     except ValueError as e:
         logger.error("Transcode job %s aborted: %s", media_id, str(e))
-        media.transcode_status = media_model.STATUS_FAILED
+        media.transcode_status = media_model.TranscodeStatus.FAILED
         media.save(update_fields=["transcode_status", "updated_at"])
         raise
 
     logger.info("Transcoding video %s (%s) for HTTP transfer to web service", media_id, model_name)
 
-    media.transcode_status = media_model.STATUS_PROCESSING
+    media.transcode_status = media_model.TranscodeStatus.PROCESSING
     media.save(update_fields=["transcode_status", "updated_at"])
 
     tmp_source = None
@@ -204,7 +204,7 @@ def transcode_video_job(
         logger.error(
             "Failed to transcode video %s (%s): %s", media_id, model_name, exc, exc_info=True
         )
-        media.transcode_status = media_model.STATUS_FAILED
+        media.transcode_status = media_model.TranscodeStatus.FAILED
         media.save(update_fields=["transcode_status", "updated_at"])
         raise
     finally:

--- a/the_flip/apps/core/templatetags/core_extras.py
+++ b/the_flip/apps/core/templatetags/core_extras.py
@@ -176,7 +176,10 @@ def problem_report_summary(report):
         return ""
 
     description = (getattr(report, "description", "") or "").strip()
-    is_other = getattr(report, "problem_type", None) == getattr(report, "PROBLEM_OTHER", None)
+    problem_type_class = getattr(report, "ProblemType", None)
+    is_other = (
+        problem_type_class and getattr(report, "problem_type", None) == problem_type_class.OTHER
+    )
     type_display = getattr(report, "get_problem_type_display", lambda: "")()
 
     if is_other:

--- a/the_flip/apps/core/test_utils.py
+++ b/the_flip/apps/core/test_utils.py
@@ -144,7 +144,7 @@ def create_machine_model(
     name: str | None = None,
     manufacturer: str = "Test Manufacturer",
     year: int = 2020,
-    era: str = MachineModel.ERA_SS,
+    era: str = MachineModel.Era.SS,
     **kwargs,
 ) -> MachineModel:
     """Create a test MachineModel.
@@ -173,7 +173,7 @@ def create_machine_model(
 def create_machine(
     model: MachineModel | None = None,
     slug: str | None = None,
-    operational_status: str = MachineInstance.STATUS_GOOD,
+    operational_status: str = MachineInstance.OperationalStatus.GOOD,
     skip_auto_log: bool = True,
     **kwargs,
 ) -> MachineInstance:
@@ -208,8 +208,8 @@ def create_machine(
 
 def create_problem_report(
     machine: MachineInstance | None = None,
-    status: str = ProblemReport.STATUS_OPEN,
-    problem_type: str = ProblemReport.PROBLEM_OTHER,
+    status: str = ProblemReport.Status.OPEN,
+    problem_type: str = ProblemReport.ProblemType.OTHER,
     description: str | None = None,
     **kwargs,
 ) -> ProblemReport:
@@ -299,7 +299,7 @@ def create_part_request(
     text: str | None = None,
     requested_by: Maintainer | None = None,
     machine: MachineInstance | None = None,
-    status: str = PartRequest.STATUS_REQUESTED,
+    status: str = PartRequest.Status.REQUESTED,
     **kwargs,
 ) -> PartRequest:
     """Create a test PartRequest.

--- a/the_flip/apps/core/views.py
+++ b/the_flip/apps/core/views.py
@@ -99,7 +99,7 @@ class TranscodeStatusView(View):
     def _build_status_result(self, media, media_model) -> dict:
         """Build status result dict for a media item."""
         result = {"status": media.transcode_status}
-        if media.transcode_status == media_model.STATUS_READY:
+        if media.transcode_status == media_model.TranscodeStatus.READY:
             if media.transcoded_file:
                 result["video_url"] = media.transcoded_file.url
             if media.poster_file:

--- a/the_flip/apps/discord/formatters.py
+++ b/the_flip/apps/discord/formatters.py
@@ -146,7 +146,7 @@ def _format_problem_report_created(report: ProblemReport) -> dict:
 
     # Get photos with thumbnails (up to 4 for Discord gallery)
     photos = list(
-        report.media.filter(media_type=ProblemReportMedia.TYPE_PHOTO)
+        report.media.filter(media_type=ProblemReportMedia.MediaType.PHOTO)
         .exclude(thumbnail_file="")
         .order_by("display_order", "created_at")[:4]
     )
@@ -219,7 +219,7 @@ def _format_log_entry_created(log_entry: LogEntry) -> dict:
 
     # Get photos with thumbnails (up to 4 for Discord gallery)
     photos = list(
-        log_entry.media.filter(media_type=LogEntryMedia.TYPE_PHOTO)  # type: ignore[attr-defined]
+        log_entry.media.filter(media_type=LogEntryMedia.MediaType.PHOTO)  # type: ignore[attr-defined]
         .exclude(thumbnail_file="")
         .order_by("display_order", "created_at")[:4]
     )
@@ -263,7 +263,7 @@ def _format_part_request_created(part_request: PartRequest) -> dict:
 
     # Get photos with thumbnails (up to 4 for Discord gallery)
     photos = list(
-        part_request.media.filter(media_type=PartRequestMedia.TYPE_PHOTO)
+        part_request.media.filter(media_type=PartRequestMedia.MediaType.PHOTO)
         .exclude(thumbnail_file="")
         .order_by("display_order", "created_at")[:4]
     )
@@ -356,7 +356,7 @@ def _format_part_request_update_created(update: PartRequestUpdate) -> dict:
 
     # Get photos with thumbnails (up to 4 for Discord gallery)
     photos = list(
-        update.media.filter(media_type=PartRequestUpdateMedia.TYPE_PHOTO)
+        update.media.filter(media_type=PartRequestUpdateMedia.MediaType.PHOTO)
         .exclude(thumbnail_file="")
         .order_by("display_order", "created_at")[:4]
     )

--- a/the_flip/apps/discord/records.py
+++ b/the_flip/apps/discord/records.py
@@ -208,7 +208,7 @@ def _create_problem_report(
     return ProblemReport.objects.create(
         machine=machine,
         description=description,
-        problem_type=ProblemReport.PROBLEM_OTHER,
+        problem_type=ProblemReport.ProblemType.OTHER,
         reported_by_user=maintainer.user if maintainer else None,
         reported_by_name="" if maintainer else fallback_name,
     )

--- a/the_flip/apps/discord/tests/test_formatters.py
+++ b/the_flip/apps/discord/tests/test_formatters.py
@@ -66,7 +66,7 @@ class DiscordFormatterTests(TemporaryMediaMixin, TestCase):
         for i in range(3):
             media = ProblemReportMedia(
                 problem_report=report,
-                media_type=ProblemReportMedia.TYPE_PHOTO,
+                media_type=ProblemReportMedia.MediaType.PHOTO,
                 display_order=i,
             )
             media.file.save(f"test{i}.jpg", ContentFile(b"fake image data"), save=False)
@@ -137,7 +137,7 @@ class DiscordFormatterTests(TemporaryMediaMixin, TestCase):
         for i in range(3):
             media = LogEntryMedia(
                 log_entry=log_entry,
-                media_type=LogEntryMedia.TYPE_PHOTO,
+                media_type=LogEntryMedia.MediaType.PHOTO,
                 display_order=i,
             )
             media.file.save(f"test{i}.jpg", ContentFile(b"fake image data"), save=False)
@@ -237,7 +237,7 @@ class PartRequestWebhookFormatterTests(TemporaryMediaMixin, TestCase):
             text="Need new flipper rubbers",
             requested_by=self.maintainer,
             machine=self.machine,
-            status=PartRequest.STATUS_ORDERED,
+            status=PartRequest.Status.ORDERED,
         )
         message = format_discord_message("part_request_status_changed", part_request)
 
@@ -285,7 +285,7 @@ class PartRequestWebhookFormatterTests(TemporaryMediaMixin, TestCase):
         for i in range(3):
             media = PartRequestMedia(
                 part_request=part_request,
-                media_type=PartRequestMedia.TYPE_PHOTO,
+                media_type=PartRequestMedia.MediaType.PHOTO,
                 display_order=i,
             )
             media.file.save(f"test{i}.jpg", ContentFile(b"fake image data"), save=False)
@@ -330,7 +330,7 @@ class PartRequestWebhookFormatterTests(TemporaryMediaMixin, TestCase):
         for i in range(3):
             media = PartRequestUpdateMedia(
                 update=update,
-                media_type=PartRequestUpdateMedia.TYPE_PHOTO,
+                media_type=PartRequestUpdateMedia.MediaType.PHOTO,
                 display_order=i,
             )
             media.file.save(f"test{i}.jpg", ContentFile(b"fake image data"), save=False)

--- a/the_flip/apps/discord/tests/test_signals.py
+++ b/the_flip/apps/discord/tests/test_signals.py
@@ -111,7 +111,7 @@ class PartRequestWebhookSignalTests(TestCase):
                 part_request=part_request,
                 posted_by=self.maintainer,
                 text="Ordered it",
-                new_status=PartRequest.STATUS_ORDERED,
+                new_status=PartRequest.Status.ORDERED,
             )
 
         # Should fire both update_created and status_changed

--- a/the_flip/apps/maintenance/forms.py
+++ b/the_flip/apps/maintenance/forms.py
@@ -76,7 +76,7 @@ class ProblemReportForm(StyledFormMixin, forms.ModelForm):
         cleaned = super().clean()
         problem_type = cleaned.get("problem_type")
         description = (cleaned.get("description") or "").strip()
-        if problem_type == ProblemReport.PROBLEM_OTHER and not description:
+        if problem_type == ProblemReport.ProblemType.OTHER and not description:
             self.add_error("description", "Please describe the problem.")
         return cleaned
 

--- a/the_flip/apps/maintenance/management/commands/check_worker.py
+++ b/the_flip/apps/maintenance/management/commands/check_worker.py
@@ -59,8 +59,11 @@ class Command(BaseCommand):
 
     def _stuck_videos(self):
         stuck_videos = LogEntryMedia.objects.filter(
-            media_type=LogEntryMedia.TYPE_VIDEO,
-            transcode_status__in=[LogEntryMedia.STATUS_PENDING, LogEntryMedia.STATUS_PROCESSING],
+            media_type=LogEntryMedia.MediaType.VIDEO,
+            transcode_status__in=[
+                LogEntryMedia.TranscodeStatus.PENDING,
+                LogEntryMedia.TranscodeStatus.PROCESSING,
+            ],
             created__lt=timezone.now() - timedelta(minutes=15),
         ).count()
         if stuck_videos:

--- a/the_flip/apps/maintenance/management/commands/create_sample_maintenance_records.py
+++ b/the_flip/apps/maintenance/management/commands/create_sample_maintenance_records.py
@@ -154,9 +154,9 @@ class Command(BaseCommand):
                 maintainer_name = (row.get("Maintainer") or "").strip()
                 maintainer = self.find_maintainer(maintainer_name) if maintainer_name else None
                 status = (
-                    ProblemReport.STATUS_CLOSED
+                    ProblemReport.Status.CLOSED
                     if (row.get("Checked / Unchecked") or "").lower() == "checked"
-                    else ProblemReport.STATUS_OPEN
+                    else ProblemReport.Status.OPEN
                 )
                 created_at = self.parse_date(row.get("Timestamp") or "")
 
@@ -164,7 +164,7 @@ class Command(BaseCommand):
                     machine=machine,
                     description=description,
                     status=status,
-                    problem_type=ProblemReport.PROBLEM_OTHER,
+                    problem_type=ProblemReport.ProblemType.OTHER,
                     reported_by_user=maintainer.user if maintainer else None,
                 )
                 ProblemReport.objects.filter(pk=report.pk).update(created_at=created_at)

--- a/the_flip/apps/maintenance/models.py
+++ b/the_flip/apps/maintenance/models.py
@@ -18,27 +18,20 @@ from the_flip.apps.core.models import AbstractMedia, TimeStampedMixin
 
 class ProblemReportQuerySet(models.QuerySet):
     def open(self):
-        return self.filter(status=ProblemReport.STATUS_OPEN)
+        return self.filter(status=ProblemReport.Status.OPEN)
 
 
 class ProblemReport(TimeStampedMixin):
     """Visitor-submitted problem report about a machine."""
 
-    STATUS_OPEN = "open"
-    STATUS_CLOSED = "closed"
-    STATUS_CHOICES = [
-        (STATUS_OPEN, "Open"),
-        (STATUS_CLOSED, "Closed"),
-    ]
+    class Status(models.TextChoices):
+        OPEN = "open", "Open"
+        CLOSED = "closed", "Closed"
 
-    PROBLEM_STUCK_BALL = "stuck_ball"
-    PROBLEM_NO_CREDITS = "no_credits"
-    PROBLEM_OTHER = "other"
-    PROBLEM_TYPE_CHOICES = [
-        (PROBLEM_STUCK_BALL, "Stuck Ball"),
-        (PROBLEM_NO_CREDITS, "No Credits"),
-        (PROBLEM_OTHER, "Other"),
-    ]
+    class ProblemType(models.TextChoices):
+        STUCK_BALL = "stuck_ball", "Stuck Ball"
+        NO_CREDITS = "no_credits", "No Credits"
+        OTHER = "other", "Other"
 
     machine = models.ForeignKey(
         MachineInstance,
@@ -47,14 +40,14 @@ class ProblemReport(TimeStampedMixin):
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=STATUS_OPEN,
+        choices=Status.choices,
+        default=Status.OPEN,
         db_index=True,
     )
     problem_type = models.CharField(
         max_length=50,
-        choices=PROBLEM_TYPE_CHOICES,
-        default=PROBLEM_OTHER,
+        choices=ProblemType.choices,
+        default=ProblemType.OTHER,
         db_index=True,
     )
     description = models.TextField(blank=True)

--- a/the_flip/apps/maintenance/tests/test_api.py
+++ b/the_flip/apps/maintenance/tests/test_api.py
@@ -113,9 +113,9 @@ class ReceiveTranscodedMediaViewTests(
         )
         self.media = LogEntryMedia.objects.create(
             log_entry=self.log_entry,
-            media_type=LogEntryMedia.TYPE_VIDEO,
+            media_type=LogEntryMedia.MediaType.VIDEO,
             file=original_file,
-            transcode_status=LogEntryMedia.STATUS_PROCESSING,
+            transcode_status=LogEntryMedia.TranscodeStatus.PROCESSING,
         )
 
         # Generate token dynamically to avoid triggering secret scanners
@@ -225,7 +225,7 @@ class ReceiveTranscodedMediaViewTests(
         self.assertIn("successfully", result["message"].lower())
 
         self.media.refresh_from_db()
-        self.assertEqual(self.media.transcode_status, LogEntryMedia.STATUS_READY)
+        self.assertEqual(self.media.transcode_status, LogEntryMedia.TranscodeStatus.READY)
         self.assertTrue(self.media.transcoded_file)
         self.assertTrue(self.media.poster_file)
         self.assertFalse(self.media.file)
@@ -246,7 +246,7 @@ class ReceiveTranscodedMediaViewTests(
         self.assertTrue(result["success"])
 
         self.media.refresh_from_db()
-        self.assertEqual(self.media.transcode_status, LogEntryMedia.STATUS_READY)
+        self.assertEqual(self.media.transcode_status, LogEntryMedia.TranscodeStatus.READY)
         self.assertTrue(self.media.transcoded_file)
         self.assertFalse(self.media.poster_file)
 
@@ -275,9 +275,9 @@ class ServeSourceMediaViewTests(
         )
         self.media = LogEntryMedia.objects.create(
             log_entry=self.log_entry,
-            media_type=LogEntryMedia.TYPE_VIDEO,
+            media_type=LogEntryMedia.MediaType.VIDEO,
             file=original_file,
-            transcode_status=LogEntryMedia.STATUS_PENDING,
+            transcode_status=LogEntryMedia.TranscodeStatus.PENDING,
         )
 
         # Generate token dynamically to avoid triggering secret scanners
@@ -371,7 +371,7 @@ class DeleteMediaTests(TemporaryMediaMixin, TestDataMixin, TestCase):
         thumb = resize_image_file(converted)
         self.media = LogEntryMedia.objects.create(
             log_entry=self.log_entry,
-            media_type=LogEntryMedia.TYPE_PHOTO,
+            media_type=LogEntryMedia.MediaType.PHOTO,
             file=converted,
             thumbnail_file=thumb,
         )
@@ -401,11 +401,11 @@ class DeleteMediaTests(TemporaryMediaMixin, TestDataMixin, TestCase):
 
         video_media = LogEntryMedia.objects.create(
             log_entry=self.log_entry,
-            media_type=LogEntryMedia.TYPE_VIDEO,
+            media_type=LogEntryMedia.MediaType.VIDEO,
             file=original,
             transcoded_file=transcoded,
             poster_file=poster,
-            transcode_status=LogEntryMedia.STATUS_READY,
+            transcode_status=LogEntryMedia.TranscodeStatus.READY,
         )
 
         original_name = video_media.file.name

--- a/the_flip/apps/maintenance/tests/test_log_entries.py
+++ b/the_flip/apps/maintenance/tests/test_log_entries.py
@@ -590,7 +590,7 @@ class LogEntryProblemReportTests(TestDataMixin, TestCase):
         super().setUp()
         self.problem_report = create_problem_report(
             machine=self.machine,
-            problem_type=ProblemReport.PROBLEM_STUCK_BALL,
+            problem_type=ProblemReport.ProblemType.STUCK_BALL,
             description="Ball stuck in the playfield",
         )
         self.create_url = reverse(
@@ -686,7 +686,7 @@ class LogEntryProblemReportTests(TestDataMixin, TestCase):
     def test_close_problem_checkbox_closes_problem_report(self):
         """Checking 'close the problem report' should close it when creating log entry."""
         self.client.force_login(self.staff_user)
-        self.assertEqual(self.problem_report.status, ProblemReport.STATUS_OPEN)
+        self.assertEqual(self.problem_report.status, ProblemReport.Status.OPEN)
 
         response = self.client.post(
             self.create_url,
@@ -700,12 +700,12 @@ class LogEntryProblemReportTests(TestDataMixin, TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.problem_report.refresh_from_db()
-        self.assertEqual(self.problem_report.status, ProblemReport.STATUS_CLOSED)
+        self.assertEqual(self.problem_report.status, ProblemReport.Status.CLOSED)
 
     def test_without_close_problem_checkbox_leaves_problem_open(self):
         """Not checking 'close the problem report' should leave it open."""
         self.client.force_login(self.staff_user)
-        self.assertEqual(self.problem_report.status, ProblemReport.STATUS_OPEN)
+        self.assertEqual(self.problem_report.status, ProblemReport.Status.OPEN)
 
         response = self.client.post(
             self.create_url,
@@ -718,7 +718,7 @@ class LogEntryProblemReportTests(TestDataMixin, TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.problem_report.refresh_from_db()
-        self.assertEqual(self.problem_report.status, ProblemReport.STATUS_OPEN)
+        self.assertEqual(self.problem_report.status, ProblemReport.Status.OPEN)
 
 
 @tag("views")

--- a/the_flip/apps/parts/forms.py
+++ b/the_flip/apps/parts/forms.py
@@ -71,7 +71,7 @@ class PartRequestUpdateForm(StyledFormMixin, forms.ModelForm):
     )
     new_status = forms.ChoiceField(
         label="Change status to",
-        choices=[("", "No change")] + list(PartRequest.STATUS_CHOICES),
+        choices=[("", "No change")] + list(PartRequest.Status.choices),
         required=False,
         widget=forms.Select(attrs={"class": "form-input"}),
     )

--- a/the_flip/apps/parts/models.py
+++ b/the_flip/apps/parts/models.py
@@ -17,34 +17,29 @@ class PartRequestQuerySet(models.QuerySet):
 
     def active(self):
         """Return part requests that are not cancelled."""
-        return self.exclude(status=PartRequest.STATUS_CANCELLED)
+        return self.exclude(status=PartRequest.Status.CANCELLED)
 
     def pending(self):
         """Return part requests that are requested or ordered (not yet received)."""
-        return self.filter(status__in=[PartRequest.STATUS_REQUESTED, PartRequest.STATUS_ORDERED])
+        return self.filter(status__in=[PartRequest.Status.REQUESTED, PartRequest.Status.ORDERED])
 
 
 class PartRequest(TimeStampedMixin):
     """A request for a part needed for maintenance."""
 
-    STATUS_REQUESTED = "requested"
-    STATUS_ORDERED = "ordered"
-    STATUS_RECEIVED = "received"
-    STATUS_CANCELLED = "cancelled"
-    STATUS_CHOICES = [
-        (STATUS_REQUESTED, "Requested"),
-        (STATUS_ORDERED, "Ordered"),
-        (STATUS_RECEIVED, "Received"),
-        (STATUS_CANCELLED, "Cancelled"),
-    ]
+    class Status(models.TextChoices):
+        REQUESTED = "requested", "Requested"
+        ORDERED = "ordered", "Ordered"
+        RECEIVED = "received", "Received"
+        CANCELLED = "cancelled", "Cancelled"
 
     text = models.TextField(
         help_text="Description of the part needed and why.",
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=STATUS_REQUESTED,
+        choices=Status.choices,
+        default=Status.REQUESTED,
         db_index=True,
     )
     requested_by = models.ForeignKey(
@@ -86,10 +81,10 @@ class PartRequest(TimeStampedMixin):
     def status_display_class(self) -> str:
         """Return CSS class for status badge styling."""
         return {
-            self.STATUS_REQUESTED: "requested",
-            self.STATUS_ORDERED: "ordered",
-            self.STATUS_RECEIVED: "received",
-            self.STATUS_CANCELLED: "cancelled",
+            self.Status.REQUESTED.value: "requested",
+            self.Status.ORDERED.value: "ordered",
+            self.Status.RECEIVED.value: "received",
+            self.Status.CANCELLED.value: "cancelled",
         }.get(self.status, "")
 
     @property
@@ -159,7 +154,7 @@ class PartRequestUpdate(TimeStampedMixin):
     )
     new_status = models.CharField(
         max_length=20,
-        choices=PartRequest.STATUS_CHOICES,
+        choices=PartRequest.Status.choices,
         blank=True,
         help_text="If set, this update changed the part request status.",
     )

--- a/the_flip/apps/parts/tests.py
+++ b/the_flip/apps/parts/tests.py
@@ -33,7 +33,7 @@ class PartRequestModelTests(TestCase):
             requested_by=self.maintainer,
             machine=self.machine,
         )
-        self.assertEqual(part_request.status, PartRequest.STATUS_REQUESTED)
+        self.assertEqual(part_request.status, PartRequest.Status.REQUESTED)
         self.assertEqual(part_request.requested_by, self.maintainer)
         self.assertEqual(part_request.machine, self.machine)
 
@@ -63,7 +63,7 @@ class PartRequestModelTests(TestCase):
         """All status choices are valid."""
         part_request = create_part_request(requested_by=self.maintainer)
 
-        for status, _ in PartRequest.STATUS_CHOICES:
+        for status, _ in PartRequest.Status.choices:
             part_request.status = status
             part_request.save()
             part_request.refresh_from_db()
@@ -73,16 +73,16 @@ class PartRequestModelTests(TestCase):
         """status_display_class returns correct CSS class."""
         part_request = create_part_request(requested_by=self.maintainer)
 
-        part_request.status = PartRequest.STATUS_REQUESTED
+        part_request.status = PartRequest.Status.REQUESTED
         self.assertEqual(part_request.status_display_class, "requested")
 
-        part_request.status = PartRequest.STATUS_ORDERED
+        part_request.status = PartRequest.Status.ORDERED
         self.assertEqual(part_request.status_display_class, "ordered")
 
-        part_request.status = PartRequest.STATUS_RECEIVED
+        part_request.status = PartRequest.Status.RECEIVED
         self.assertEqual(part_request.status_display_class, "received")
 
-        part_request.status = PartRequest.STATUS_CANCELLED
+        part_request.status = PartRequest.Status.CANCELLED
         self.assertEqual(part_request.status_display_class, "cancelled")
 
     def test_requester_display_with_fk(self):
@@ -134,9 +134,9 @@ class PartRequestUpdateModelTests(TestCase):
             part_request=self.part_request,
             posted_by=self.maintainer,
             text="Ordered from Marco Specialties",
-            new_status=PartRequest.STATUS_ORDERED,
+            new_status=PartRequest.Status.ORDERED,
         )
-        self.assertEqual(update.new_status, PartRequest.STATUS_ORDERED)
+        self.assertEqual(update.new_status, PartRequest.Status.ORDERED)
 
     def test_str_representation(self):
         """String representation shows update info."""
@@ -150,16 +150,16 @@ class PartRequestUpdateModelTests(TestCase):
 
     def test_update_changes_part_request_status(self):
         """Creating update with new_status changes the part request status."""
-        self.assertEqual(self.part_request.status, PartRequest.STATUS_REQUESTED)
+        self.assertEqual(self.part_request.status, PartRequest.Status.REQUESTED)
 
         create_part_request_update(
             part_request=self.part_request,
             posted_by=self.maintainer,
-            new_status=PartRequest.STATUS_ORDERED,
+            new_status=PartRequest.Status.ORDERED,
         )
 
         self.part_request.refresh_from_db()
-        self.assertEqual(self.part_request.status, PartRequest.STATUS_ORDERED)
+        self.assertEqual(self.part_request.status, PartRequest.Status.ORDERED)
 
     def test_poster_display_with_fk(self):
         """poster_display returns maintainer name when FK is set."""
@@ -324,16 +324,16 @@ class PartRequestUpdateViewTests(TestCase):
             reverse("part-request-update-create", kwargs={"pk": self.part_request.pk}),
             {
                 "text": "Ordered from Marco",
-                "new_status": PartRequest.STATUS_ORDERED,
+                "new_status": PartRequest.Status.ORDERED,
             },
         )
         self.assertEqual(response.status_code, 302)
         update = PartRequestUpdate.objects.first()
-        self.assertEqual(update.new_status, PartRequest.STATUS_ORDERED)
+        self.assertEqual(update.new_status, PartRequest.Status.ORDERED)
 
         # Check the part request status was updated
         self.part_request.refresh_from_db()
-        self.assertEqual(self.part_request.status, PartRequest.STATUS_ORDERED)
+        self.assertEqual(self.part_request.status, PartRequest.Status.ORDERED)
 
 
 @tag("views", "ajax")
@@ -477,22 +477,22 @@ class PartRequestListFilterTests(TestCase):
         self.requested = create_part_request(
             text="Requested part",
             requested_by=self.maintainer,
-            status=PartRequest.STATUS_REQUESTED,
+            status=PartRequest.Status.REQUESTED,
         )
         self.ordered = create_part_request(
             text="Ordered part",
             requested_by=self.maintainer,
-            status=PartRequest.STATUS_ORDERED,
+            status=PartRequest.Status.ORDERED,
         )
         self.received = create_part_request(
             text="Received part",
             requested_by=self.maintainer,
-            status=PartRequest.STATUS_RECEIVED,
+            status=PartRequest.Status.RECEIVED,
         )
         self.cancelled = create_part_request(
             text="Cancelled part",
             requested_by=self.maintainer,
-            status=PartRequest.STATUS_CANCELLED,
+            status=PartRequest.Status.CANCELLED,
         )
 
     def test_search_by_status_requested(self):

--- a/the_flip/apps/parts/views.py
+++ b/the_flip/apps/parts/views.py
@@ -79,15 +79,15 @@ class PartRequestListView(CanAccessMaintainerPortalMixin, TemplateView):
         # Stats for sidebar
         stats = [
             {
-                "value": PartRequest.objects.filter(status=PartRequest.STATUS_REQUESTED).count(),
+                "value": PartRequest.objects.filter(status=PartRequest.Status.REQUESTED).count(),
                 "label": "Requested",
             },
             {
-                "value": PartRequest.objects.filter(status=PartRequest.STATUS_ORDERED).count(),
+                "value": PartRequest.objects.filter(status=PartRequest.Status.ORDERED).count(),
                 "label": "Ordered",
             },
             {
-                "value": PartRequest.objects.filter(status=PartRequest.STATUS_RECEIVED).count(),
+                "value": PartRequest.objects.filter(status=PartRequest.Status.RECEIVED).count(),
                 "label": "Received",
             },
         ]
@@ -229,11 +229,11 @@ class PartRequestCreateView(CanAccessMaintainerPortalMixin, FormView):
 
                 media = PartRequestMedia.objects.create(
                     part_request=part_request,
-                    media_type=PartRequestMedia.TYPE_VIDEO
+                    media_type=PartRequestMedia.MediaType.VIDEO
                     if is_video
-                    else PartRequestMedia.TYPE_PHOTO,
+                    else PartRequestMedia.MediaType.PHOTO,
                     file=media_file,
-                    transcode_status=PartRequestMedia.STATUS_PENDING if is_video else "",
+                    transcode_status=PartRequestMedia.TranscodeStatus.PENDING if is_video else "",
                 )
 
                 if is_video:
@@ -416,11 +416,13 @@ class PartRequestUpdateCreateView(CanAccessMaintainerPortalMixin, FormView):
 
                 media = PartRequestUpdateMedia.objects.create(
                     update=update,
-                    media_type=PartRequestUpdateMedia.TYPE_VIDEO
+                    media_type=PartRequestUpdateMedia.MediaType.VIDEO
                     if is_video
-                    else PartRequestUpdateMedia.TYPE_PHOTO,
+                    else PartRequestUpdateMedia.MediaType.PHOTO,
                     file=media_file,
-                    transcode_status=PartRequestUpdateMedia.STATUS_PENDING if is_video else "",
+                    transcode_status=PartRequestUpdateMedia.TranscodeStatus.PENDING
+                    if is_video
+                    else "",
                 )
 
                 if is_video:
@@ -502,7 +504,7 @@ class PartRequestStatusUpdateView(CanAccessMaintainerPortalMixin, View):
 
         if action == "update_status":
             new_status = request.POST.get("status")
-            if new_status not in dict(PartRequest.STATUS_CHOICES):
+            if new_status not in PartRequest.Status.values:
                 return JsonResponse({"error": "Invalid status"}, status=400)
 
             if part_request.status == new_status:
@@ -510,7 +512,7 @@ class PartRequestStatusUpdateView(CanAccessMaintainerPortalMixin, View):
 
             # Get old status display before change
             old_display = part_request.get_status_display()
-            new_display = dict(PartRequest.STATUS_CHOICES).get(new_status, new_status)
+            new_display = PartRequest.Status(new_status).label
 
             # Get the maintainer for the current user
             maintainer = get_object_or_404(Maintainer, user=request.user)


### PR DESCRIPTION
## Summary
Closes #131

Migrates all model choice fields from class-level constants + `*_CHOICES` lists to Django's `TextChoices` pattern.

**Models refactored:**
- `ProblemReport.Status` and `ProblemReport.ProblemType`
- `MachineInstance.OperationalStatus`
- `MachineModel.Era`
- `PartRequest.Status`
- `AbstractMedia.MediaType` and `AbstractMedia.TranscodeStatus`

**Key changes:**
- Replaced `Model.STATUS_X` constants with nested `Model.Status.X` enum classes
- Updated all views, forms, querysets, signals, and templates to use new pattern
- Fixed template references to use `model.Status.choices` instead of `model.STATUS_CHOICES`
- Added try/except in signals.py for defensive enum conversion of legacy status values
- Updated documentation in `docs/Models.md`

**No database migration needed** - string values remain unchanged.

## Test plan
- [x] All 390 tests pass
- [x] Pre-commit hooks pass
- [x] Manual verification of status dropdowns on machine detail page
- [x] Manual verification of parts request status dropdown on `/parts/<id>/`
- [x] Manual verification of problem report list filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated status, type, and choice constants into Django TextChoices enums across models and templates. Updated all internal references to use the new enum-based structure. No visible functionality changes; system behavior remains identical.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->