### PR TITLE
Add docstrings to public APIs for improved coverage

### DIFF
--- a/the_flip/apps/accounts/models.py
+++ b/the_flip/apps/accounts/models.py
@@ -9,6 +9,8 @@ from the_flip.apps.core.models import TimeStampedMixin
 
 
 class Maintainer(TimeStampedMixin):
+    """Profile extending Django User for museum maintainers."""
+
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     is_shared_account = models.BooleanField(
         default=False,
@@ -26,6 +28,7 @@ class Maintainer(TimeStampedMixin):
 
     @property
     def display_name(self) -> str:
+        """Return full name if available, otherwise username."""
         full_name = self.user.get_full_name()
         return full_name or self.user.get_username()
 

--- a/the_flip/apps/catalog/models.py
+++ b/the_flip/apps/catalog/models.py
@@ -41,6 +41,8 @@ class MachineModel(TimeStampedMixin):
     """Represents a pinball machine model."""
 
     class Era(models.TextChoices):
+        """Technology era classification for pinball machines."""
+
         PM = "PM", "Pure Mechanical"
         EM = "EM", "Electromechanical"
         SS = "SS", "Solid State"
@@ -140,6 +142,7 @@ class MachineModel(TimeStampedMixin):
         return self.name
 
     def get_admin_history_url(self) -> str:
+        """Return URL to this model's Django admin change history."""
         return reverse("admin:catalog_machinemodel_history", args=[self.pk])
 
     def save(self, *args, **kwargs):
@@ -155,7 +158,10 @@ class MachineModel(TimeStampedMixin):
 
 
 class MachineInstanceQuerySet(models.QuerySet):
+    """Custom queryset for MachineInstance with common filters."""
+
     def visible(self):
+        """Return machines with related model and location pre-fetched."""
         return self.select_related("model", "location")
 
     def active_for_matching(self):
@@ -177,6 +183,8 @@ class MachineInstance(TimeStampedMixin):
     """Physical machine owned by the museum."""
 
     class OperationalStatus(models.TextChoices):
+        """Current working condition of a physical machine."""
+
         GOOD = "good", "Good"
         FIXING = "fixing", "Fixing"
         BROKEN = "broken", "Broken"
@@ -250,16 +258,20 @@ class MachineInstance(TimeStampedMixin):
 
     @property
     def display_name(self) -> str:
+        """Return custom name if set, otherwise the model name."""
         return self.name_override or self.model.name
 
     @property
     def ownership_display(self) -> str:
+        """Return ownership credit or default collection name."""
         return self.ownership_credit or "The Flip Collection"
 
     def get_absolute_url(self):
+        """Return the public-facing URL for this machine."""
         return reverse("public-machine-detail", args=[self.slug])
 
     def get_admin_history_url(self) -> str:
+        """Return URL to this instance's Django admin change history."""
         return reverse("admin:catalog_machineinstance_history", args=[self.pk])
 
     def save(self, *args, **kwargs):

--- a/the_flip/apps/catalog/views.py
+++ b/the_flip/apps/catalog/views.py
@@ -130,6 +130,8 @@ def get_activity_page(machine, page_num, page_size=10, search_query=None):
 
 
 class MachineListViewForPublic(ListView):
+    """Public machine list showing status and open problems, sorted by priority."""
+
     template_name = "catalog/machine_list_public.html"
     context_object_name = "machines"
 
@@ -182,6 +184,8 @@ class MachineListViewForPublic(ListView):
 
 
 class MachineListView(CanAccessMaintainerPortalMixin, MachineListViewForPublic):
+    """Maintainer machine list with location stats in the sidebar."""
+
     template_name = "catalog/machine_list_for_maintainers.html"
 
     def get_context_data(self, **kwargs):
@@ -207,6 +211,8 @@ class MachineListView(CanAccessMaintainerPortalMixin, MachineListViewForPublic):
 
 
 class MachineDetailViewForPublic(DetailView):
+    """Public machine detail page with problem report form."""
+
     template_name = "catalog/machine_detail_public.html"
     queryset = MachineInstance.objects.visible()
     slug_field = "slug"
@@ -247,13 +253,17 @@ class MachineDetailViewForMaintainers(CanAccessMaintainerPortalMixin, MachineDet
 
         # Create a simple page_obj-like object for template compatibility
         class SimplePage:
+            """Lightweight page stub providing has_next()/next_page_number() for templates."""
+
             def __init__(self, has_next):
                 self._has_next = has_next
 
             def has_next(self):
+                """Return whether more pages exist."""
                 return self._has_next
 
             def next_page_number(self):
+                """Return the next page number (always 2 for first page)."""
                 return 2
 
         context["page_obj"] = SimplePage(has_next)

--- a/the_flip/apps/core/models.py
+++ b/the_flip/apps/core/models.py
@@ -155,10 +155,14 @@ class AbstractMedia(TimeStampedMixin):
     parent_field_name: ClassVar[str]
 
     class MediaType(models.TextChoices):
+        """Type of media attachment."""
+
         PHOTO = "photo", "Photo"
         VIDEO = "video", "Video"
 
     class TranscodeStatus(models.TextChoices):
+        """Status of video transcoding for web playback."""
+
         PENDING = "pending", "Pending"
         PROCESSING = "processing", "Processing"
         READY = "ready", "Ready"

--- a/the_flip/apps/core/templatetags/core_extras.py
+++ b/the_flip/apps/core/templatetags/core_extras.py
@@ -98,6 +98,7 @@ def render_markdown(text):
 
 @register.filter
 def smart_date(value):
+    """Render a datetime as a <time> element for client-side formatting."""
     if not value:
         return ""
     if timezone.is_naive(value):

--- a/the_flip/apps/core/views.py
+++ b/the_flip/apps/core/views.py
@@ -10,6 +10,8 @@ from the_flip.apps.core.models import get_media_model
 
 
 class HomeView(TemplateView):
+    """Public landing page for the maintainer portal."""
+
     template_name = "home.html"
 
     def get_context_data(self, **kwargs):

--- a/the_flip/apps/discord/bot.py
+++ b/the_flip/apps/discord/bot.py
@@ -44,20 +44,24 @@ class WizardState:
 
     @property
     def current_suggestion(self) -> RecordSuggestion | None:
+        """Return the suggestion currently being reviewed, or None if complete."""
         if 0 <= self.current_index < len(self.suggestions):
             return self.suggestions[self.current_index]
         return None
 
     @property
     def is_complete(self) -> bool:
+        """Return True if all suggestions have been processed."""
         return self.current_index >= len(self.suggestions)
 
     @property
     def total_count(self) -> int:
+        """Return the total number of suggestions in this wizard session."""
         return len(self.suggestions)
 
     @property
     def step_number(self) -> int:
+        """Return the 1-indexed step number for display."""
         return self.current_index + 1
 
     def record_result(self, action: str, url: str | None = None):
@@ -74,10 +78,12 @@ class WizardState:
 
     @property
     def created_count(self) -> int:
+        """Return how many suggestions were created as records."""
         return sum(1 for r in self.results if r.action == "created")
 
     @property
     def skipped_count(self) -> int:
+        """Return how many suggestions were skipped by the user."""
         return sum(1 for r in self.results if r.action == "skipped")
 
 

--- a/the_flip/apps/discord/llm.py
+++ b/the_flip/apps/discord/llm.py
@@ -44,14 +44,17 @@ class AnalysisResult:
 
     @property
     def is_error(self) -> bool:
+        """Return True if analysis failed."""
         return self.error is not None
 
     @classmethod
     def success(cls, suggestions: list[RecordSuggestion]) -> AnalysisResult:
+        """Create a successful result with suggestions."""
         return cls(suggestions=suggestions, error=None)
 
     @classmethod
     def failure(cls, error: str) -> AnalysisResult:
+        """Create a failed result with an error message."""
         return cls(suggestions=[], error=error)
 
 

--- a/the_flip/apps/maintenance/models.py
+++ b/the_flip/apps/maintenance/models.py
@@ -17,7 +17,10 @@ from the_flip.apps.core.models import AbstractMedia, TimeStampedMixin
 
 
 class ProblemReportQuerySet(models.QuerySet):
+    """Custom queryset for ProblemReport with common filters."""
+
     def open(self):
+        """Return only open problem reports."""
         return self.filter(status=ProblemReport.Status.OPEN)
 
 
@@ -25,10 +28,14 @@ class ProblemReport(TimeStampedMixin):
     """Visitor-submitted problem report about a machine."""
 
     class Status(models.TextChoices):
+        """Whether a problem report is still active or resolved."""
+
         OPEN = "open", "Open"
         CLOSED = "closed", "Closed"
 
     class ProblemType(models.TextChoices):
+        """Categories of problems visitors can report."""
+
         STUCK_BALL = "stuck_ball", "Stuck Ball"
         NO_CREDITS = "no_credits", "No Credits"
         OTHER = "other", "Other"
@@ -77,10 +84,12 @@ class ProblemReport(TimeStampedMixin):
         return f"{self.machine.display_name} – {self.get_problem_type_display()}"
 
     def get_admin_history_url(self) -> str:
+        """Return URL to this report's Django admin change history."""
         return reverse("admin:maintenance_problemreport_history", args=[self.pk])
 
     @property
     def reporter_display(self) -> str:
+        """Return the best available name for who reported this problem."""
         # Prefer typed-in name (e.g., from shared terminal account)
         if self.reported_by_name:
             return self.reported_by_name
@@ -138,6 +147,7 @@ class LogEntry(TimeStampedMixin):
         return f"Log entry for {self.machine.display_name}"
 
     def get_admin_history_url(self) -> str:
+        """Return URL to this entry's Django admin change history."""
         return reverse("admin:maintenance_logentry_history", args=[self.pk])
 
     def clean(self):
@@ -157,6 +167,7 @@ class LogEntry(TimeStampedMixin):
 
 
 def log_media_upload_to(instance: LogEntryMedia, filename: str) -> str:
+    """Generate upload path for log entry media files."""
     return f"log_entries/{instance.log_entry_id}/{uuid4()}-{filename}"
 
 
@@ -186,10 +197,12 @@ class LogEntryMedia(AbstractMedia):
         return f"{self.get_media_type_display()} for log entry {self.log_entry_id}"
 
     def get_admin_history_url(self) -> str:
+        """Return URL to this media's Django admin change history."""
         return reverse("admin:maintenance_logentrymedia_history", args=[self.pk])
 
 
 def problem_report_media_upload_to(instance: ProblemReportMedia, filename: str) -> str:
+    """Generate upload path for problem report media files."""
     return f"problem_reports/{instance.problem_report_id}/{uuid4()}-{filename}"
 
 
@@ -221,4 +234,5 @@ class ProblemReportMedia(AbstractMedia):
         return f"{self.get_media_type_display()} for problem report {self.problem_report_id}"
 
     def get_admin_history_url(self) -> str:
+        """Return URL to this media's Django admin change history."""
         return reverse("admin:maintenance_problemreportmedia_history", args=[self.pk])

--- a/the_flip/apps/maintenance/views.py
+++ b/the_flip/apps/maintenance/views.py
@@ -757,6 +757,8 @@ class ProblemReportDetailView(MediaUploadMixin, CanAccessMaintainerPortalMixin, 
 
 
 class MachineLogView(CanAccessMaintainerPortalMixin, TemplateView):
+    """View all log entries for a specific machine."""
+
     template_name = "maintenance/machine_log.html"
 
     def dispatch(self, request, *args, **kwargs):
@@ -800,6 +802,8 @@ class MachineLogView(CanAccessMaintainerPortalMixin, TemplateView):
 
 
 class MachineLogCreateView(CanAccessMaintainerPortalMixin, FormView):
+    """Create a new log entry for a machine or problem report."""
+
     template_name = "maintenance/log_entry_new.html"
     form_class = LogEntryQuickForm
 
@@ -964,6 +968,8 @@ class MachineLogCreateView(CanAccessMaintainerPortalMixin, FormView):
 
 
 class MachineLogPartialView(CanAccessMaintainerPortalMixin, View):
+    """AJAX endpoint for infinite scrolling in machine log view."""
+
     template_name = "maintenance/partials/log_entry.html"
 
     def get(self, request, *args, **kwargs):
@@ -1056,6 +1062,8 @@ class LogListPartialView(CanAccessMaintainerPortalMixin, View):
 
 
 class LogEntryDetailView(MediaUploadMixin, CanAccessMaintainerPortalMixin, DetailView):
+    """Detail page for a single log entry with media upload support."""
+
     model = LogEntry
     template_name = "maintenance/log_entry_detail.html"
     context_object_name = "entry"

--- a/the_flip/apps/parts/models.py
+++ b/the_flip/apps/parts/models.py
@@ -28,6 +28,8 @@ class PartRequest(TimeStampedMixin):
     """A request for a part needed for maintenance."""
 
     class Status(models.TextChoices):
+        """Lifecycle state of a part request."""
+
         REQUESTED = "requested", "Requested"
         ORDERED = "ordered", "Ordered"
         RECEIVED = "received", "Received"


### PR DESCRIPTION
## Summary
Addresses #140 - Improve docstring coverage to meet CodeRabbit's 80% threshold.

- Added docstrings to model classes, view classes, template tags, and utility functions across 11 files
- Focused on public APIs: models, views, template tags, and Discord bot/LLM modules
- Clarified on the issue that test docstrings ARE required per `docs/Testing.md`

## Changes
- `accounts/models.py`: Maintainer class and display_name property
- `catalog/models.py`: Era, OperationalStatus, MachineInstanceQuerySet, and related methods
- `catalog/views.py`: Machine list/detail view classes
- `core/models.py`: MediaType, TranscodeStatus enums
- `core/templatetags/core_extras.py`: smart_date filter
- `core/views.py`: HomeView
- `discord/bot.py`: WizardState properties
- `discord/llm.py`: AnalysisResult methods
- `maintenance/models.py`: Status, ProblemType, querysets, and upload path functions
- `maintenance/views.py`: Log view classes
- `parts/models.py`: Status enum

## Test plan
- [x] All 388 tests pass
- [x] `make quality` passes (format, lint, typecheck)
- [x] `make precommit` passes (16/16 hooks)
- [x] Code review agents found no critical issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added and expanded docstrings across the application (accounts, catalog, core, discord, maintenance, parts, and views), plus guidance in the docs on when/how to document. These updates improve code clarity for maintainers and reviewers without changing any user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->