### PR TITLE
Set CodeRabbit docstring threshold to 60%

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/reference/configuration
+
+reviews:
+  pre_merge_checks:
+    docstrings:
+      threshold: 60
+      mode: warning


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` configuration file
- Sets docstring coverage threshold to 60% (current coverage: 67.44%)
- Uses warning mode (non-blocking)

This prevents CodeRabbit from complaining about docstring coverage while still maintaining basic documentation standards.

## Test plan
- [ ] CodeRabbit should no longer flag docstring coverage in reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code review configuration to enforce documentation standards during the pre-merge review process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->