### PR TITLE
Refactor DisplayNameWithUsernameFilterTests to use create_user fixture

### DIFF
--- a/the_flip/apps/core/tests.py
+++ b/the_flip/apps/core/tests.py
@@ -10,6 +10,7 @@ from the_flip.apps.core.templatetags.core_extras import (
     display_name_with_username,
     render_markdown,
 )
+from the_flip.apps.core.test_utils import create_user
 
 
 class RenderMarkdownFilterTests(TestCase):
@@ -117,43 +118,23 @@ class DisplayNameWithUsernameFilterTests(TestCase):
 
     def test_username_only(self):
         """User with no name returns just username."""
-
-        class MockUser:
-            first_name = ""
-            last_name = ""
-            username = "jsmith"
-
-        self.assertEqual(display_name_with_username(MockUser()), "jsmith")
+        user = create_user(username="jsmith")
+        self.assertEqual(display_name_with_username(user), "jsmith")
 
     def test_first_name_only(self):
         """User with only first name returns 'First (username)'."""
-
-        class MockUser:
-            first_name = "John"
-            last_name = ""
-            username = "jsmith"
-
-        self.assertEqual(display_name_with_username(MockUser()), "John (jsmith)")
+        user = create_user(username="jsmith", first_name="John")
+        self.assertEqual(display_name_with_username(user), "John (jsmith)")
 
     def test_last_name_only(self):
         """User with only last name returns 'Last (username)'."""
-
-        class MockUser:
-            first_name = ""
-            last_name = "Smith"
-            username = "jsmith"
-
-        self.assertEqual(display_name_with_username(MockUser()), "Smith (jsmith)")
+        user = create_user(username="jsmith", last_name="Smith")
+        self.assertEqual(display_name_with_username(user), "Smith (jsmith)")
 
     def test_full_name(self):
         """User with full name returns 'First Last (username)'."""
-
-        class MockUser:
-            first_name = "John"
-            last_name = "Smith"
-            username = "jsmith"
-
-        self.assertEqual(display_name_with_username(MockUser()), "John Smith (jsmith)")
+        user = create_user(username="jsmith", first_name="John", last_name="Smith")
+        self.assertEqual(display_name_with_username(user), "John Smith (jsmith)")
 
 
 @tag("views")


### PR DESCRIPTION
## Summary
- Replace duplicate MockUser class definitions with calls to the existing `create_user()` test fixture
- Eliminates DRY violations and uses real User model instances instead of mock objects
- Net reduction of 19 lines of code

Closes #150

## Test plan
- [x] All tests pass (`make test`)
- [x] Pre-commit hooks pass (`make precommit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test utilities to improve consistency and maintainability across the test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->