### PR TITLE
Use functools.partial for transaction.on_commit callback

### DIFF
--- a/the_flip/apps/maintenance/views.py
+++ b/the_flip/apps/maintenance/views.py
@@ -1479,8 +1479,7 @@ class ReceiveTranscodedMediaView(View):
             # This prevents data loss if save() fails
             if original_file_name:
                 storage = media.transcoded_file.storage
-                file_to_delete = original_file_name
-                transaction.on_commit(lambda: storage.delete(file_to_delete))
+                transaction.on_commit(partial(storage.delete, name=original_file_name))
 
             return JsonResponse(
                 {


### PR DESCRIPTION
## Summary
- Replace bare lambda with `functools.partial()` using keyword argument for deferred file deletion
- Follows project convention documented in CLAUDE.md

## Context
An AI code review flagged this as a style violation. The project rule states:
> Use `functools.partial` for deferred calls: use `partial(func, kwarg=val)` with keyword arguments for `transaction.on_commit()` and similar callbacks.

## Test plan
- [x] `make quality` passes
- [x] `make test` passes (423 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to file deletion logic for enhanced maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->