### PR TITLE
Fix agent-docs-no-direct-edit hook false positive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
       # Block direct edits to generated agent docs (unless source or script also changed)
       - id: agent-docs-no-direct-edit
         name: agent-docs-no-direct-edit
-        entry: 'bash -c "git diff --cached --name-only | grep -qE \"(docs/AGENTS.src.md|scripts/build_agent_docs.py)\" && exit 0; echo Error: CLAUDE.md and AGENTS.md are auto-generated. && echo Edit docs/AGENTS.src.md instead, then run: make agent-docs && exit 1"'
+        entry: 'bash -c "git diff --cached --name-only | grep -qE \"^(CLAUDE|AGENTS)\\.md$\" || exit 0; git diff --cached --name-only | grep -qE \"(docs/AGENTS.src.md|scripts/build_agent_docs.py)\" && exit 0; echo Error: CLAUDE.md and AGENTS.md are auto-generated. && echo Edit docs/AGENTS.src.md instead, then run: make agent-docs && exit 1"'
         language: system
         files: ^(CLAUDE|AGENTS)\.md$
         exclude: ^docs/


### PR DESCRIPTION
## Summary
- Fix pre-commit hook that was failing on `pre-commit run --all-files` even when `CLAUDE.md` and `AGENTS.md` weren't being modified

## Problem
The `agent-docs-no-direct-edit` hook triggers on files matching `^(CLAUDE|AGENTS)\.md$`. When running `--all-files`, it would fail because those files exist, even though they weren't staged for commit.

## Solution
Added an early exit check: if the generated files aren't actually staged, skip the hook entirely.

```bash
git diff --cached --name-only | grep -qE "^(CLAUDE|AGENTS)\\.md$" || exit 0
```

## Test plan
- [x] `make precommit` now passes
- [x] Hook still correctly fails when directly editing CLAUDE.md (verified manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced commit validation rules to allow documentation-related commits with greater flexibility based on file modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->