### PR TITLE
Use functools.partial for remaining transaction.on_commit callbacks

### DIFF
--- a/the_flip/apps/discord/signals.py
+++ b/the_flip/apps/discord/signals.py
@@ -1,5 +1,7 @@
 """Django signals for Discord webhook triggers."""
 
+from functools import partial
+
 from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
@@ -20,7 +22,8 @@ def problem_report_saved(sender, instance, created, **kwargs):
     # which trigger log_entry_created webhooks. No separate events needed.
     if created:
         transaction.on_commit(
-            lambda: dispatch_webhook(
+            partial(
+                dispatch_webhook,
                 event_type="problem_report_created",
                 object_id=instance.pk,
                 model_name="ProblemReport",
@@ -38,7 +41,8 @@ def log_entry_created(sender, instance, created, **kwargs):
     """
     if created:
         transaction.on_commit(
-            lambda: dispatch_webhook(
+            partial(
+                dispatch_webhook,
                 event_type="log_entry_created",
                 object_id=instance.pk,
                 model_name="LogEntry",
@@ -55,7 +59,8 @@ def part_request_saved(sender, instance, created, **kwargs):
     """
     if created:
         transaction.on_commit(
-            lambda: dispatch_webhook(
+            partial(
+                dispatch_webhook,
                 event_type="part_request_created",
                 object_id=instance.pk,
                 model_name="PartRequest",
@@ -86,7 +91,8 @@ def part_request_status_changed(sender, instance, created, **kwargs):
         old_status = getattr(instance, "_old_status", None)
         if old_status and old_status != instance.status:
             transaction.on_commit(
-                lambda: dispatch_webhook(
+                partial(
+                    dispatch_webhook,
                     event_type="part_request_status_changed",
                     object_id=instance.pk,
                     model_name="PartRequest",
@@ -103,7 +109,8 @@ def part_request_update_created(sender, instance, created, **kwargs):
     """
     if created:
         transaction.on_commit(
-            lambda: dispatch_webhook(
+            partial(
+                dispatch_webhook,
                 event_type="part_request_update_created",
                 object_id=instance.pk,
                 model_name="PartRequestUpdate",

--- a/the_flip/apps/parts/views.py
+++ b/the_flip/apps/parts/views.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from pathlib import Path
 
 from django.contrib import messages
@@ -237,9 +238,12 @@ class PartRequestCreateView(CanAccessMaintainerPortalMixin, FormView):
                 )
 
                 if is_video:
-                    media_id = media.id
                     transaction.on_commit(
-                        lambda mid=media_id: enqueue_transcode(mid, model_name="PartRequestMedia")
+                        partial(
+                            enqueue_transcode,
+                            media_id=media.id,
+                            model_name="PartRequestMedia",
+                        )
                     )
 
         messages.success(
@@ -426,10 +430,11 @@ class PartRequestUpdateCreateView(CanAccessMaintainerPortalMixin, FormView):
                 )
 
                 if is_video:
-                    media_id = media.id
                     transaction.on_commit(
-                        lambda mid=media_id: enqueue_transcode(
-                            mid, model_name="PartRequestUpdateMedia"
+                        partial(
+                            enqueue_transcode,
+                            media_id=media.id,
+                            model_name="PartRequestUpdateMedia",
                         )
                     )
 


### PR DESCRIPTION
## Summary
- Convert lambda callbacks to `partial()` with keyword arguments in:
  - `discord/signals.py` (5 instances)
  - `parts/views.py` (2 instances)

This completes the codebase-wide adoption of the `partial()` pattern for deferred callbacks, per project convention in CLAUDE.md.

## Context
Follows PR #155 which fixed the same pattern in `maintenance/views.py`.

## Test plan
- [x] `make quality` passes
- [x] `make test` passes (423 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved callback handling in webhook and transcode task dispatch mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->