### PR TITLE
Add explicit ordering to get_log_entry_queryset()

### DIFF
--- a/the_flip/apps/maintenance/views/log_entries.py
+++ b/the_flip/apps/maintenance/views/log_entries.py
@@ -50,6 +50,7 @@ def get_log_entry_queryset(search_query: str = ""):
         .select_related("machine", "machine__model", "problem_report")
         .prefetch_related("maintainers__user", "media")
         .search(search_query)
+        .order_by("-work_date")
     )
 
     return queryset


### PR DESCRIPTION
## Summary

Add `.order_by("-work_date")` to `get_log_entry_queryset()` to ensure reliable pagination.

## Problem

Without explicit ordering, pagination behavior is undefined - items may appear on multiple pages or be skipped across different database backends.

## Fix

One-line change adding `.order_by("-work_date")` to match the pattern used in machine-specific views.

Fixes #169

## Test plan

- [x] All 443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)