### PR TITLE
Extract JavaScript documentation to docs/Javascript.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,8 @@ STOP and read the relevant doc before writing code.  Code that doesn't follow do
 
 | Task | Read First |
 |------|------------|
-| Templates, HTML, CSS, Javascript | [`docs/HTML_CSS.md`](docs/HTML_CSS.md) |
+| Templates, HTML, CSS | [`docs/HTML_CSS.md`](docs/HTML_CSS.md) |
+| JavaScript patterns & components | [`docs/Javascript.md`](docs/Javascript.md) |
 | Views, CBVs, query optimization | [`docs/Views.md`](docs/Views.md) |
 | Forms & inputs | [`docs/Forms.md`](docs/Forms.md) |
 | Defining models or querysets | [`docs/Models.md`](docs/Models.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ STOP and read the relevant doc before writing code.  Code that doesn't follow do
 
 | Task | Read First |
 |------|------------|
-| Templates, HTML, CSS, Javascript | [`docs/HTML_CSS.md`](docs/HTML_CSS.md) |
+| Templates, HTML, CSS | [`docs/HTML_CSS.md`](docs/HTML_CSS.md) |
+| JavaScript patterns & components | [`docs/Javascript.md`](docs/Javascript.md) |
 | Views, CBVs, query optimization | [`docs/Views.md`](docs/Views.md) |
 | Forms & inputs | [`docs/Forms.md`](docs/Forms.md) |
 | Defining models or querysets | [`docs/Models.md`](docs/Models.md) |

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -69,7 +69,8 @@ STOP and read the relevant doc before writing code.  Code that doesn't follow do
 
 | Task | Read First |
 |------|------------|
-| Templates, HTML, CSS, Javascript | [`docs/HTML_CSS.md`](docs/HTML_CSS.md) |
+| Templates, HTML, CSS | [`docs/HTML_CSS.md`](docs/HTML_CSS.md) |
+| JavaScript patterns & components | [`docs/Javascript.md`](docs/Javascript.md) |
 | Views, CBVs, query optimization | [`docs/Views.md`](docs/Views.md) |
 | Forms & inputs | [`docs/Forms.md`](docs/Forms.md) |
 | Defining models or querysets | [`docs/Models.md`](docs/Models.md) |

--- a/docs/HTML_CSS.md
+++ b/docs/HTML_CSS.md
@@ -64,69 +64,7 @@ The project establishes component patterns in [the_flip/static/core/styles.css](
 
 ## JavaScript
 
-### Module Pattern
-
-This project uses vanilla JavaScript with IIFEs (Immediately Invoked Function Expressions) rather than ES modules:
-
-```javascript
-(function () {
-  'use strict';
-  // Module code here - all variables are scoped to this function
-})();
-```
-
-**Why IIFEs instead of ES modules:**
-- No bundler required - works with Django's `collectstatic`
-- Simple `<script defer>` loading without `type="module"` complexity
-- No import path management (ES modules require full URLs, not bare specifiers)
-- Works everywhere without CORS considerations
-
-For a low-JS project like this, IIFEs are the pragmatic choice. If the project grows to need significant JS sharing between modules, consider adding a bundler (esbuild) and switching to ES modules.
-
-### Script Loading
-
-Always use `defer` when including scripts:
-
-```html
-<script src="{% static 'core/my_script.js' %}" defer></script>
-```
-
-### Cross-Module Communication
-
-When JS modules need to communicate, use custom DOM events rather than globals:
-
-```javascript
-// Dispatch event on a specific element (preferred) or document
-container.dispatchEvent(new CustomEvent('maintainer:selected', {
-  detail: { maintainer, input }
-}));
-
-// Listen for event
-container.addEventListener('maintainer:selected', (e) => {
-  console.log(e.detail.maintainer);
-});
-```
-
-**Do not use global callbacks** like `window.onSomething = function() {...}` or `data-on-select="globalFunctionName"`. These pollute the global namespace and create hidden coupling between modules. Custom events are explicit, discoverable, and don't require the listener to exist when the event is dispatched.
-
-### Visibility Pattern
-
-When toggling element visibility with JavaScript, use the `.hidden` class instead of `style.display`:
-
-```html
-<!-- In template -->
-<div id="my-element" class="hidden">...</div>
-```
-
-```javascript
-// In JavaScript - show element
-element.classList.remove('hidden');
-
-// Hide element
-element.classList.add('hidden');
-```
-
-This keeps styling in CSS and makes the pattern consistent across the codebase.
+See [Javascript.md](Javascript.md) for JavaScript patterns and component documentation.
 
 ## CSS Class Naming
 

--- a/docs/Javascript.md
+++ b/docs/Javascript.md
@@ -1,0 +1,167 @@
+# JavaScript Development Guide
+
+This guide covers JavaScript patterns and components for this project.
+
+The project uses vanilla JavaScript with IIFEs (no bundler), data-attribute auto-initialization, and custom events for cross-component communication.
+
+
+## Module Pattern
+
+This project uses IIFEs (Immediately Invoked Function Expressions) rather than ES modules:
+
+```javascript
+(function () {
+  'use strict';
+  // Module code here - all variables are scoped to this function
+})();
+```
+
+**Why IIFEs instead of ES modules:**
+- No bundler required - works with Django's `collectstatic`
+- Simple `<script defer>` loading without `type="module"` complexity
+- No import path management (ES modules require full URLs, not bare specifiers)
+- Works everywhere without CORS considerations
+
+For a low-JS project like this, IIFEs are the pragmatic choice. If the project grows to need significant JS sharing between modules, consider adding a bundler (esbuild) and switching to ES modules.
+
+
+## Script Loading
+
+Always use `defer` when including scripts:
+
+```html
+<script src="{% static 'core/my_script.js' %}" defer></script>
+```
+
+
+## Cross-Module Communication
+
+When JS modules need to communicate, use custom DOM events rather than globals:
+
+```javascript
+// Dispatch event on a specific element (preferred) or document
+container.dispatchEvent(new CustomEvent('maintainer:selected', {
+  detail: { maintainer, input }
+}));
+
+// Listen for event
+container.addEventListener('maintainer:selected', (e) => {
+  console.log(e.detail.maintainer);
+});
+```
+
+**Do not use global callbacks** like `window.onSomething = function() {...}` or `data-on-select="globalFunctionName"`. These pollute the global namespace and create hidden coupling between modules. Custom events are explicit, discoverable, and don't require the listener to exist when the event is dispatched.
+
+
+## Visibility Pattern
+
+When toggling element visibility with JavaScript, use the `.hidden` class instead of `style.display`:
+
+```html
+<!-- In template -->
+<div id="my-element" class="hidden">...</div>
+```
+
+```javascript
+// In JavaScript - show element
+element.classList.remove('hidden');
+
+// Hide element
+element.classList.add('hidden');
+```
+
+This keeps styling in CSS and makes the pattern consistent across the codebase.
+
+
+## Data-Attribute Auto-Init Pattern
+
+Most components use data attributes for configuration-driven initialization. The standard pattern:
+
+1. Mark the root element with a data attribute (e.g., `data-file-accumulator`)
+2. Query for all matching elements on `DOMContentLoaded`
+3. Initialize each instance
+
+```javascript
+(function () {
+  'use strict';
+
+  function initMyComponent(container) {
+    // Component logic here
+    // Read configuration from data attributes
+    const apiUrl = container.dataset.apiUrl;
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-my-component]').forEach(initMyComponent);
+  });
+})();
+```
+
+This pattern allows multiple instances per page and keeps HTML declarative.
+
+
+## Component Catalog
+
+All JavaScript files are in `the_flip/static/core/`.
+
+### Core
+
+| File | Purpose |
+|------|---------|
+| core.js | Utilities, dropdowns, clickable cards, smart dates |
+
+### Autocomplete
+
+| File | Purpose |
+|------|---------|
+| machine_autocomplete.js | Machine search with API-backed results |
+| maintainer_autocomplete.js | Maintainer search with prefetched results |
+
+### File & Media
+
+| File | Purpose |
+|------|---------|
+| file_accumulator.js | Multi-file upload that accumulates across selections |
+| media_grid.js | Media gallery with upload and delete |
+| video_transcode_poll.js | Poll server for video transcoding status |
+
+### Inline Editing
+
+| File | Purpose |
+|------|---------|
+| text_edit.js | Inline text editing with markdown preview |
+| sidebar_card_edit.js | Sidebar dropdown editing (machine, problem) |
+
+### Lists & Navigation
+
+| File | Purpose |
+|------|---------|
+| infinite_scroll.js | Infinite scroll pagination for log entries |
+| machine_filter.js | Client-side machine list filtering |
+
+### Factories
+
+These are utility functions called by other components rather than auto-initializing on page load. Import by including the script, then call the factory function.
+
+| File | Purpose |
+|------|---------|
+| dropdown_keyboard.js | Keyboard navigation for dropdowns |
+| searchable_dropdown.js | Searchable dropdown creation |
+
+### Page-Specific
+
+| File | Purpose |
+|------|---------|
+| log_entry_detail.js | Auto-save for log entry work date and maintainers |
+
+
+## Custom Events
+
+Events document the contract between components:
+
+| Event | Dispatched by | Listened by | Purpose |
+|-------|---------------|-------------|---------|
+| `card:initialize` | infinite_scroll.js | core.js | Re-bind clickable cards after dynamic content |
+| `maintainer:selected` | maintainer_autocomplete.js | log_entry_detail.js | Maintainer selected from autocomplete |
+| `media:uploaded` | media_grid.js | video_transcode_poll.js | Video uploaded, start polling |
+| `media:ready` | video_transcode_poll.js | media_grid.js | Video transcoding complete |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ The development documentation for The Flip maintenance system.
 - **[Datamodel.md](Datamodel.md)** - Catalog of the project's data models
 - **[Models.md](Models.md)** - Data model patterns, custom querysets, database field conventions
 - **[Views.md](Views.md)** - View patterns, CBVs, query optimization, access control
-- **[HTML_CSS.md](HTML_CSS.md)** - HTML templates, CSS styling, page layouts, JavaScript patterns, component conventions
+- **[HTML_CSS.md](HTML_CSS.md)** - HTML templates, CSS styling, page layouts, CSS component conventions
+- **[Javascript.md](Javascript.md)** - JavaScript patterns, JS component catalog, custom events
 - **[Forms.md](Forms.md)** - Form rendering, markup patterns, optional field marking, CSS classes
 - **[Django_Python.md](Django_Python.md)** - Python coding rules (mixins, secrets, linting, file organization)
 - **[Testing.md](Testing.md)** - Test patterns, utilities, tagging, runner configuration


### PR DESCRIPTION
## Summary

- Create `docs/Javascript.md` with JS patterns and component catalog
- Remove JS section from `HTML_CSS.md`, replace with link
- Add `Javascript.md` to required reading table in `AGENTS.src.md`
- Add `Javascript.md` to `docs/README.md` index

## Details

The project now has 13 JavaScript components in `the_flip/static/core/`, but JS documentation was buried as a subsection in `docs/HTML_CSS.md`. This extracts it into its own file with:

- **Patterns**: Module pattern (IIFEs), script loading, cross-module communication, visibility pattern, data-attribute auto-init
- **Component Catalog**: Grouped by purpose (Core, Autocomplete, File & Media, Inline Editing, Lists & Navigation, Factories, Page-Specific)
- **Custom Events**: Documents the contract between components with dispatcher/listener relationships

Closes #174

## Test plan

- [x] `make quality` passes
- [x] `make test` passes (443 tests)
- [x] `make precommit` passes
- [x] All cross-references verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation structure to provide better clarity and navigation.
  * Introduced a dedicated JavaScript Development Guide documenting project conventions, patterns, and component catalogs.
  * Updated documentation references to reflect the new organization and improved separation of frontend technologies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->