### PR TITLE
Fix maintainer attribution on auto-generated log entries

### DIFF
--- a/the_flip/apps/catalog/tests.py
+++ b/the_flip/apps/catalog/tests.py
@@ -10,6 +10,7 @@ from the_flip.apps.core.test_utils import (
     create_machine,
     create_machine_model,
     create_maintainer_user,
+    create_shared_terminal,
     create_user,
 )
 from the_flip.apps.maintenance.models import LogEntry
@@ -451,6 +452,40 @@ class MachineInlineUpdateViewTests(TestCase):
         self.assertEqual(log.created_by, self.maintainer_user)
         self.assertEqual(log.maintainers.count(), 0)
 
+    def test_status_change_skips_shared_terminal(self):
+        """Auto log entry should NOT add shared terminal as maintainer."""
+        shared_terminal = create_shared_terminal()
+        self.client.force_login(shared_terminal.user)
+
+        self.machine.operational_status = MachineInstance.OperationalStatus.GOOD
+        self.machine._skip_auto_log = True
+        self.machine.save()
+
+        self.client.post(
+            self.update_url, {"action": "update_status", "operational_status": "broken"}
+        )
+
+        log = LogEntry.objects.filter(machine=self.machine).latest("created_at")
+        self.assertEqual(log.created_by, shared_terminal.user)
+        # Shared terminal should NOT be added as maintainer
+        self.assertEqual(log.maintainers.count(), 0)
+
+    def test_location_change_skips_shared_terminal(self):
+        """Auto log entry should NOT add shared terminal as maintainer for location changes."""
+        shared_terminal = create_shared_terminal()
+        self.client.force_login(shared_terminal.user)
+
+        self.machine.location = self.workshop
+        self.machine._skip_auto_log = True
+        self.machine.save()
+
+        self.client.post(self.update_url, {"action": "update_location", "location": "floor"})
+
+        log = LogEntry.objects.filter(machine=self.machine).latest("created_at")
+        self.assertEqual(log.created_by, shared_terminal.user)
+        # Shared terminal should NOT be added as maintainer
+        self.assertEqual(log.maintainers.count(), 0)
+
 
 @tag("views")
 class MachineActivitySearchTests(TestCase):
@@ -657,3 +692,88 @@ class MachineInstanceModelTests(TestCase):
         instance2 = MachineInstance.objects.create(model=self.model)
         self.assertNotEqual(instance1.slug, instance2.slug)
         self.assertEqual(instance2.slug, "test-model-2")
+
+
+@tag("models", "signals")
+class MachineCreationSignalTests(TestCase):
+    """Tests for automatic log entry creation when machines are created."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.maintainer_user = create_maintainer_user()
+        self.model = create_machine_model(name="Signal Test Model")
+
+    def test_new_machine_creates_log_entry(self):
+        """Creating a new machine should create an automatic log entry."""
+        instance = MachineInstance.objects.create(
+            model=self.model,
+            created_by=self.maintainer_user,
+        )
+
+        log = LogEntry.objects.filter(machine=instance).first()
+        self.assertIsNotNone(log)
+        self.assertIn("New machine added", log.text)
+        self.assertIn(instance.display_name, log.text)
+
+    def test_new_machine_log_entry_has_created_by(self):
+        """The auto log entry should have created_by set to the machine creator."""
+        instance = MachineInstance.objects.create(
+            model=self.model,
+            created_by=self.maintainer_user,
+        )
+
+        log = LogEntry.objects.filter(machine=instance).first()
+        self.assertEqual(log.created_by, self.maintainer_user)
+
+    def test_new_machine_log_entry_adds_maintainer_if_exists(self):
+        """The auto log entry should add the creator as a maintainer if they have a profile."""
+        maintainer = Maintainer.objects.get(user=self.maintainer_user)
+
+        instance = MachineInstance.objects.create(
+            model=self.model,
+            created_by=self.maintainer_user,
+        )
+
+        log = LogEntry.objects.filter(machine=instance).first()
+        self.assertIn(maintainer, log.maintainers.all())
+
+    def test_new_machine_log_entry_no_maintainer_if_not_exists(self):
+        """The auto log entry should not fail if the creator has no Maintainer profile."""
+        # Remove the maintainer profile
+        Maintainer.objects.filter(user=self.maintainer_user).delete()
+
+        instance = MachineInstance.objects.create(
+            model=self.model,
+            created_by=self.maintainer_user,
+        )
+
+        log = LogEntry.objects.filter(machine=instance).first()
+        self.assertIsNotNone(log)
+        self.assertEqual(log.maintainers.count(), 0)
+
+    def test_new_machine_log_entry_no_created_by(self):
+        """Creating a machine without created_by should still create log entry."""
+        instance = MachineInstance.objects.create(
+            model=self.model,
+            created_by=None,
+        )
+
+        log = LogEntry.objects.filter(machine=instance).first()
+        self.assertIsNotNone(log)
+        self.assertIsNone(log.created_by)
+        self.assertEqual(log.maintainers.count(), 0)
+
+    def test_new_machine_log_entry_skips_shared_terminal(self):
+        """The auto log entry should NOT add shared terminal as maintainer."""
+        shared_terminal = create_shared_terminal()
+
+        instance = MachineInstance.objects.create(
+            model=self.model,
+            created_by=shared_terminal.user,
+        )
+
+        log = LogEntry.objects.filter(machine=instance).first()
+        self.assertIsNotNone(log)
+        self.assertEqual(log.created_by, shared_terminal.user)
+        # Shared terminal should NOT be added as maintainer
+        self.assertEqual(log.maintainers.count(), 0)


### PR DESCRIPTION
## Summary
- Fixed bug where "New machine added" log entries weren't displaying the creator's name
- The signal was setting `created_by` but not adding the user to `maintainers` (which is what the template displays)
- Updated `_add_maintainer_if_exists()` to skip shared terminal accounts
- Moved inline imports to top of file (no circular dependency exists since signals load via `AppConfig.ready()`)

## Test plan
- [x] Added 6 tests for machine creation signal behavior
- [x] Added 2 tests for shared terminal handling on status/location changes
- [x] All 470 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected automatic maintainer attribution in machine logs to exclude shared terminal accounts.
  * Enhanced automatic log creation for machine lifecycle events to ensure accurate tracking of creation, status changes, and location changes with proper maintainer attribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->