### PR TITLE
Update ruff hook from legacy alias to ruff-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v0.14.10
     hooks:
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter
       - id: ruff-format


### PR DESCRIPTION
## Summary
- Changed pre-commit hook from `ruff` to `ruff-check`
- The bare `ruff` command is a legacy alias that shows "(legacy alias)" in output
- Using `ruff-check` explicitly silences this warning

## Test plan
- [x] `make precommit` now shows `ruff check` instead of `ruff (legacy alias)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling configuration. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->