### PR TITLE
Add self.maintainer to TestDataMixin

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -114,7 +114,7 @@ Mixins provide reusable test fixtures and behaviors.
 
 | Mixin | When to Use |
 |-------|-------------|
-| `TestDataMixin` | Most tests. Provides `self.machine`, `self.maintainer_user`, `self.regular_user`, `self.superuser` |
+| `TestDataMixin` | Most tests. Provides `self.machine`, `self.maintainer_user`, `self.maintainer`, `self.regular_user`, `self.superuser` |
 | `SuppressRequestLogsMixin` | View tests that expect 302/403/400 responses. Silences log noise. |
 | `SharedAccountTestMixin` | Testing "who are you?" flows. Provides `self.shared_user`, `self.shared_maintainer`, `self.identifying_user`, `self.identifying_maintainer` |
 | `TemporaryMediaMixin` | Media upload tests. Isolates MEDIA_ROOT per test. |

--- a/the_flip/apps/core/test_utils.py
+++ b/the_flip/apps/core/test_utils.py
@@ -491,6 +491,7 @@ class TestDataMixin:
         - self.machine_model: A MachineModel instance
         - self.machine: A MachineInstance instance
         - self.maintainer_user: A User with maintainer portal access
+        - self.maintainer: The Maintainer profile for maintainer_user
         - self.regular_user: A User without special permissions
         - self.superuser: A superuser (admin)
 
@@ -510,6 +511,7 @@ class TestDataMixin:
             slug="test-machine",
         )
         self.maintainer_user = create_maintainer_user()
+        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
         self.regular_user = create_user()
         self.superuser = create_superuser()
 

--- a/the_flip/apps/parts/tests/test_feature_flags.py
+++ b/the_flip/apps/parts/tests/test_feature_flags.py
@@ -4,7 +4,6 @@ from constance.test import override_config
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
     TestDataMixin,
     create_part_request,
@@ -14,10 +13,6 @@ from the_flip.apps.core.test_utils import (
 @tag("feature_flags")
 class PartsFeatureFlagTests(TestDataMixin, TestCase):
     """Tests for the PARTS_ENABLED feature flag."""
-
-    def setUp(self):
-        super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
     def test_nav_link_hidden_when_disabled(self):
         """Parts nav link is hidden when PARTS_ENABLED is False."""

--- a/the_flip/apps/parts/tests/test_part_request_create.py
+++ b/the_flip/apps/parts/tests/test_part_request_create.py
@@ -3,7 +3,6 @@
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
     SharedAccountTestMixin,
     SuppressRequestLogsMixin,
@@ -15,10 +14,6 @@ from the_flip.apps.parts.models import PartRequest
 @tag("views")
 class PartRequestCreateViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for part request create view."""
-
-    def setUp(self):
-        super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
     def test_create_view_requires_staff(self):
         """Create view requires staff permission."""

--- a/the_flip/apps/parts/tests/test_part_request_detail.py
+++ b/the_flip/apps/parts/tests/test_part_request_detail.py
@@ -3,7 +3,6 @@
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
     SuppressRequestLogsMixin,
     TestDataMixin,
@@ -15,10 +14,6 @@ from the_flip.apps.core.test_utils import (
 @tag("views")
 class PartRequestDetailViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for part request detail view."""
-
-    def setUp(self):
-        super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
     def test_detail_view_requires_staff(self):
         """Detail view requires staff permission."""
@@ -45,7 +40,6 @@ class PartRequestDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestDataMix
 
     def setUp(self):
         super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
         self.part_request = create_part_request(
             text="Original text",
             requested_by=self.maintainer,
@@ -105,7 +99,6 @@ class PartRequestUpdateDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestD
 
     def setUp(self):
         super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
         self.part_request = create_part_request(requested_by=self.maintainer)
         self.update = create_part_request_update(
             part_request=self.part_request,

--- a/the_flip/apps/parts/tests/test_part_request_list.py
+++ b/the_flip/apps/parts/tests/test_part_request_list.py
@@ -3,7 +3,6 @@
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
     SuppressRequestLogsMixin,
     TestDataMixin,
@@ -18,10 +17,6 @@ from the_flip.apps.parts.models import (
 @tag("views")
 class PartRequestListViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for part request list view access."""
-
-    def setUp(self):
-        super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
     def test_list_view_requires_authentication(self):
         """Anonymous users should be redirected to login."""
@@ -60,7 +55,6 @@ class PartRequestListFilterTests(SuppressRequestLogsMixin, TestDataMixin, TestCa
 
     def setUp(self):
         super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
         # Create part requests with different statuses
         self.requested = create_part_request(
@@ -116,10 +110,6 @@ class PartRequestListFilterTests(SuppressRequestLogsMixin, TestDataMixin, TestCa
 @tag("views")
 class PartRequestSearchFreeTextNameTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for searching part requests by free-text name fields."""
-
-    def setUp(self):
-        super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
     def test_search_by_requested_by_name(self):
         """Can find part requests by free-text requester name."""

--- a/the_flip/apps/parts/tests/test_part_request_models.py
+++ b/the_flip/apps/parts/tests/test_part_request_models.py
@@ -2,7 +2,6 @@
 
 from django.test import TestCase, tag
 
-from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
     TestDataMixin,
     create_part_request,
@@ -17,10 +16,6 @@ from the_flip.apps.parts.models import (
 @tag("models")
 class PartRequestModelTests(TestDataMixin, TestCase):
     """Tests for the PartRequest model."""
-
-    def setUp(self):
-        super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
 
     def test_create_part_request(self):
         """Can create a part request."""
@@ -111,7 +106,6 @@ class PartRequestUpdateModelTests(TestDataMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
         self.part_request = create_part_request(requested_by=self.maintainer)
 
     def test_create_update(self):

--- a/the_flip/apps/parts/tests/test_part_request_updates.py
+++ b/the_flip/apps/parts/tests/test_part_request_updates.py
@@ -3,7 +3,6 @@
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
     SharedAccountTestMixin,
     SuppressRequestLogsMixin,
@@ -19,7 +18,6 @@ class PartRequestUpdateViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCa
 
     def setUp(self):
         super().setUp()
-        self.maintainer = Maintainer.objects.get(user=self.maintainer_user)
         self.part_request = create_part_request(requested_by=self.maintainer)
 
     def test_create_update(self):


### PR DESCRIPTION
## Summary
- Added `self.maintainer` attribute to `TestDataMixin` that provides the `Maintainer` profile for `maintainer_user`
- Removed boilerplate `self.maintainer = Maintainer.objects.get(user=self.maintainer_user)` from 10 test classes across 6 parts test files
- Removed now-unused `Maintainer` imports from all affected files
- Updated Testing.md documentation

Closes #182

## Test plan
- [x] All 472 tests pass
- [x] All quality checks pass (ruff, djlint, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Centralized maintainer fixture initialization in test utilities, eliminating redundant setup code across multiple test modules.
  * Updated test infrastructure to provide maintainer attributes automatically during test setup.

* **Documentation**
  * Updated documentation to reflect changes to test utilities structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->