### PR TITLE
Standardize test tags to 6 core tags

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -16,30 +16,25 @@ make test-models       # Run model tests only
 
 ### Test Tags
 
-| Tag | Use For |
-|-----|---------|
-| `models` | Model unit tests (no HTTP requests) |
-| `views` | View tests that make HTTP requests |
-| `ajax` | AJAX endpoints (combine with `views`: `@tag("views", "ajax")`) |
-| `media` | Media upload, delete, and display tests (combine with `views`: `@tag("views", "media")`) |
-| `forms` | Form validation tests |
-| `api` | External API endpoint tests |
-| `feature_flags` | Tests for `constance` feature flag behavior |
-| `integration` | Tests requiring external services (ffmpeg, S3, etc.) |
-| `environment` | Environment-specific checks |
-| `tasks` | Background task tests |
-| `admin` | Django admin tests |
-| `auth` | Authentication flow tests |
-| `registration` | User registration tests |
-| `public` | Public-facing (non-authenticated) page tests |
+Use these 6 tags to enable selective test execution. Each tag maps to a type of code you're editing:
+
+| Tag | Use For | When to Run |
+|-----|---------|-------------|
+| `models` | Model/queryset logic, signals, managers | Editing models, managers, signals |
+| `views` | HTTP request/response tests | Editing views, templates, URLs |
+| `forms` | Form validation logic | Editing form classes |
+| `tasks` | Background job tests (Django Q) | Editing async tasks |
+| `admin` | Django admin customizations | Editing admin.py |
+| `integration` | Tests requiring external services (ffmpeg, S3) | Exclude for fast local runs |
+
+**Keep it simple.** Don't invent new tags or combine multiple tags. One tag per test class.
 
 ### Running Tests by Tag
 
 ```bash
-python manage.py test --tag=models       # Model unit tests
-python manage.py test --tag=views        # View/HTTP tests
-python manage.py test --tag=api          # API endpoint tests
-python manage.py test --exclude-tag=integration  # Skip slow tests
+python manage.py test --tag=models              # Run model tests
+python manage.py test --tag=views               # Run view tests
+python manage.py test --exclude-tag=integration # Fast local runs
 ```
 
 

--- a/the_flip/apps/accounts/tests/test_navigation.py
+++ b/the_flip/apps/accounts/tests/test_navigation.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from the_flip.apps.core.test_utils import create_user
 
 
-@tag("views", "ui")
+@tag("views")
 class NavigationTests(TestCase):
     """Tests for navigation display based on auth state."""
 

--- a/the_flip/apps/accounts/tests/test_profile.py
+++ b/the_flip/apps/accounts/tests/test_profile.py
@@ -98,7 +98,7 @@ class ProfileViewTests(TestCase):
         self.assertRedirects(response, self.profile_url)
 
 
-@tag("views", "auth")
+@tag("views")
 class PasswordChangeViewTests(TestCase):
     """Tests for the password change view.
 

--- a/the_flip/apps/accounts/tests/test_registration.py
+++ b/the_flip/apps/accounts/tests/test_registration.py
@@ -21,7 +21,7 @@ User = get_user_model()
 TEST_PASSWORD = f"Test{secrets.token_hex(8)}!"
 
 
-@tag("views", "registration")
+@tag("views")
 class InvitationRegistrationViewTests(AccessControlTestCase):
     """Tests for the invitation registration view."""
 
@@ -145,7 +145,7 @@ class InvitationRegistrationViewTests(AccessControlTestCase):
         self.assertFalse(User.objects.filter(username="newmaintainer").exists())
 
 
-@tag("views", "registration")
+@tag("views")
 class SelfRegistrationViewTests(TestCase):
     """Tests for the self-registration view (beta feature)."""
 
@@ -306,7 +306,7 @@ class SelfRegistrationViewTests(TestCase):
         self.assertContains(response, "already registered")
 
 
-@tag("api", "ajax")
+@tag("views")
 class CheckUsernameViewTests(TestCase):
     """Tests for the check-username AJAX endpoint."""
 

--- a/the_flip/apps/accounts/tests/test_terminals.py
+++ b/the_flip/apps/accounts/tests/test_terminals.py
@@ -33,7 +33,7 @@ class TerminalTestMixin(SuppressRequestLogsMixin, TestCase):
         )
 
 
-@tag("views", "terminals")
+@tag("views")
 class TerminalListViewTests(TerminalTestMixin, TestCase):
     """Tests for the terminal list view."""
 
@@ -83,7 +83,7 @@ class TerminalListViewTests(TerminalTestMixin, TestCase):
         self.assertContains(response, "No shared terminal accounts yet")
 
 
-@tag("views", "terminals")
+@tag("views")
 class TerminalLoginViewTests(TerminalTestMixin, TestCase):
     """Tests for the terminal login view."""
 
@@ -124,7 +124,7 @@ class TerminalLoginViewTests(TerminalTestMixin, TestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@tag("views", "terminals")
+@tag("views")
 class TerminalCreateViewTests(TestCase):
     """Tests for the terminal create view."""
 
@@ -181,7 +181,7 @@ class TerminalCreateViewTests(TestCase):
         self.assertContains(response, 'data-lpignore="true"')
 
 
-@tag("views", "terminals")
+@tag("views")
 class TerminalUpdateViewTests(TerminalTestMixin, TestCase):
     """Tests for the terminal update view."""
 
@@ -252,7 +252,7 @@ class TerminalUpdateViewTests(TerminalTestMixin, TestCase):
         self.assertContains(response, "Reactivate")
 
 
-@tag("views", "terminals")
+@tag("views")
 class TerminalDeactivateViewTests(TerminalTestMixin, TestCase):
     """Tests for the terminal deactivate view."""
 
@@ -286,7 +286,7 @@ class TerminalDeactivateViewTests(TerminalTestMixin, TestCase):
         self.assertIn("deactivated", str(messages[0]))
 
 
-@tag("views", "terminals")
+@tag("views")
 class TerminalReactivateViewTests(SuppressRequestLogsMixin, TestCase):
     """Tests for the terminal reactivate view."""
 

--- a/the_flip/apps/catalog/tests.py
+++ b/the_flip/apps/catalog/tests.py
@@ -16,7 +16,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.maintenance.models import LogEntry
 
 
-@tag("views", "access-control")
+@tag("views")
 class MaintainerMachineViewsAccessTests(AccessControlTestCase):
     """Tests for maintainer machine views access control."""
 
@@ -753,7 +753,7 @@ class MachineActivitySearchTests(TestCase):
         self.assertContains(response, "Fixed the flipper")
 
 
-@tag("views", "public")
+@tag("views")
 class PublicViewTests(TestCase):
     """Tests for public-facing catalog views."""
 
@@ -992,7 +992,7 @@ class MachineInstanceModelTests(TestCase):
         self.assertEqual(instance2.slug, "same-name-2")
 
 
-@tag("models", "signals")
+@tag("models")
 class MachineCreationSignalTests(TestCase):
     """Tests for automatic log entry creation when machines are created."""
 

--- a/the_flip/apps/core/tests.py
+++ b/the_flip/apps/core/tests.py
@@ -19,6 +19,7 @@ from the_flip.apps.core.templatetags.core_extras import (
 from the_flip.apps.core.test_utils import create_user
 
 
+@tag("views")
 class RenderMarkdownFilterTests(TestCase):
     """Tests for the render_markdown template filter."""
 
@@ -115,6 +116,7 @@ class RenderMarkdownFilterTests(TestCase):
         self.assertIn("<h2>", result)
 
 
+@tag("views")
 class DisplayNameWithUsernameFilterTests(TestCase):
     """Tests for the display_name_with_username template filter."""
 
@@ -248,7 +250,7 @@ class ServeMediaViewTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@tag("templatetags")
+@tag("views")
 class MachineStatusFilterTests(TestCase):
     """Tests for MachineInstance.operational_status template filters."""
 
@@ -319,7 +321,7 @@ class MachineStatusFilterTests(TestCase):
         self.assertEqual(machine_status_btn_class(None), "btn--secondary")
 
 
-@tag("templatetags")
+@tag("views")
 class IconTagTests(TestCase):
     """Tests for the {% icon %} template tag."""
 

--- a/the_flip/apps/discord/tests/test_delivery.py
+++ b/the_flip/apps/discord/tests/test_delivery.py
@@ -4,12 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import requests
 from constance.test import override_config
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from the_flip.apps.core.test_utils import create_machine, create_problem_report
 from the_flip.apps.discord.tasks import deliver_webhook
 
 
+@tag("tasks")
 class WebhookDeliveryTests(TestCase):
     """Tests for webhook delivery logic."""
 

--- a/the_flip/apps/discord/tests/test_formatters.py
+++ b/the_flip/apps/discord/tests/test_formatters.py
@@ -1,7 +1,7 @@
 """Tests for Discord message formatting."""
 
 from django.core.files.base import ContentFile
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
@@ -23,6 +23,7 @@ from the_flip.apps.maintenance.models import LogEntryMedia
 from the_flip.apps.parts.models import PartRequest
 
 
+@tag("tasks")
 class DiscordFormatterTests(TemporaryMediaMixin, TestCase):
     """Tests for Discord message formatting.
 
@@ -260,6 +261,7 @@ class DiscordFormatterTests(TemporaryMediaMixin, TestCase):
         self.assertIn("description", embed)
 
 
+@tag("tasks")
 class PartRequestWebhookFormatterTests(TemporaryMediaMixin, TestCase):
     """Tests for part request Discord webhook formatting."""
 
@@ -497,6 +499,7 @@ class PartRequestWebhookFormatterTests(TemporaryMediaMixin, TestCase):
         self.assertIn("image", message["embeds"][0])
 
 
+@tag("tasks")
 class GetBaseUrlTests(TestCase):
     """Tests for the get_base_url helper function."""
 

--- a/the_flip/apps/discord/tests/test_models.py
+++ b/the_flip/apps/discord/tests/test_models.py
@@ -1,13 +1,14 @@
 """Tests for Discord models."""
 
 from django.db import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import create_maintainer_user
 from the_flip.apps.discord.models import DiscordUserLink
 
 
+@tag("models")
 class DiscordUserLinkModelTests(TestCase):
     """Tests for the DiscordUserLink model."""
 

--- a/the_flip/apps/discord/tests/test_signals.py
+++ b/the_flip/apps/discord/tests/test_signals.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from constance.test import override_config
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from the_flip.apps.accounts.models import Maintainer
 from the_flip.apps.core.test_utils import (
@@ -17,6 +17,7 @@ from the_flip.apps.maintenance.models import ProblemReport
 from the_flip.apps.parts.models import PartRequest
 
 
+@tag("tasks")
 @override_config(DISCORD_WEBHOOKS_ENABLED=True, DISCORD_WEBHOOK_URL="https://test.webhook")
 class WebhookSignalTests(TestCase):
     """Tests for webhook signal triggers."""
@@ -54,6 +55,7 @@ class WebhookSignalTests(TestCase):
         self.assertEqual(calls[0][0][2], log_entry.pk)
 
 
+@tag("tasks")
 @override_config(DISCORD_WEBHOOKS_ENABLED=True, DISCORD_WEBHOOK_URL="https://test.webhook")
 class PartRequestWebhookSignalTests(TestCase):
     """Tests for part request webhook signal triggers."""

--- a/the_flip/apps/maintenance/tests/test_api.py
+++ b/the_flip/apps/maintenance/tests/test_api.py
@@ -20,7 +20,7 @@ from the_flip.apps.maintenance.models import LogEntryMedia
 from the_flip.apps.maintenance.utils import resize_image_file
 
 
-@tag("api", "ajax")
+@tag("views")
 class MaintainerAutocompleteViewTests(SuppressRequestLogsMixin, TestCase):
     """Tests for the maintainer autocomplete API endpoint."""
 
@@ -98,7 +98,7 @@ class MaintainerAutocompleteViewTests(SuppressRequestLogsMixin, TestCase):
         self.assertEqual(display_names, sorted(display_names, key=str.lower))
 
 
-@tag("api")
+@tag("views")
 class ReceiveTranscodedMediaViewTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -260,7 +260,7 @@ class ReceiveTranscodedMediaViewTests(
         self.assertIn("Server not configured", response.json()["error"])
 
 
-@tag("api")
+@tag("views")
 class ServeSourceMediaViewTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -358,7 +358,7 @@ class ServeSourceMediaViewTests(
         self.assertIn("Server not configured", response.json()["error"])
 
 
-@tag("api")
+@tag("views")
 class DeleteMediaTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Ensure deleting media removes associated files (file and thumbnail)."""
 

--- a/the_flip/apps/maintenance/tests/test_environment.py
+++ b/the_flip/apps/maintenance/tests/test_environment.py
@@ -6,7 +6,7 @@ import subprocess
 from django.test import TestCase, tag
 
 
-@tag("integration", "environment")
+@tag("integration")
 class FFmpegAvailabilityTest(TestCase):
     """Tests that verify video transcoding dependencies are available."""
 

--- a/the_flip/apps/maintenance/tests/test_forms.py
+++ b/the_flip/apps/maintenance/tests/test_forms.py
@@ -7,7 +7,7 @@ from the_flip.apps.core.test_utils import DATETIME_INPUT_FORMAT, MINIMAL_PNG
 from the_flip.apps.maintenance.forms import LogEntryQuickForm
 
 
-@tag("forms", "security")
+@tag("forms")
 class LogEntryQuickFormMediaValidationTests(TestCase):
     """Tests for media file validation in LogEntryQuickForm."""
 

--- a/the_flip/apps/maintenance/tests/test_log_entry_detail.py
+++ b/the_flip/apps/maintenance/tests/test_log_entry_detail.py
@@ -17,7 +17,7 @@ from the_flip.apps.core.test_utils import (
 )
 
 
-@tag("views", "ajax")
+@tag("views")
 class LogEntryDetailViewWorkDateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for LogEntryDetailView AJAX work_date updates."""
 
@@ -94,7 +94,7 @@ class LogEntryDetailViewWorkDateTests(SuppressRequestLogsMixin, TestDataMixin, T
         self.assertFalse(result["success"])
 
 
-@tag("views", "ajax")
+@tag("views")
 class LogEntryDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for LogEntryDetailView AJAX text updates."""
 

--- a/the_flip/apps/maintenance/tests/test_log_entry_media.py
+++ b/the_flip/apps/maintenance/tests/test_log_entry_media.py
@@ -20,7 +20,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.maintenance.models import LogEntry, LogEntryMedia
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class LogEntryVideoUploadTests(TestDataMixin, TestCase):
     """Tests for video upload via AJAX on log entry creation."""
 
@@ -136,7 +136,7 @@ class LogEntryVideoUploadTests(TestDataMixin, TestCase):
         mock_enqueue.assert_not_called()
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class LogEntryMediaUploadTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -203,7 +203,7 @@ class LogEntryMediaUploadTests(
         self.assertEqual(media.media_type, LogEntryMedia.MediaType.PHOTO)
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class LogEntryMediaDeleteTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):

--- a/the_flip/apps/maintenance/tests/test_problem_report_create.py
+++ b/the_flip/apps/maintenance/tests/test_problem_report_create.py
@@ -14,7 +14,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.maintenance.models import ProblemReport
 
 
-@tag("views", "public")
+@tag("views")
 class ProblemReportCreateViewTests(TestDataMixin, TestCase):
     """Tests for the public problem report submission view."""
 

--- a/the_flip/apps/maintenance/tests/test_problem_report_detail.py
+++ b/the_flip/apps/maintenance/tests/test_problem_report_detail.py
@@ -279,7 +279,7 @@ class ProblemReportDetailViewTests(SuppressRequestLogsMixin, TestDataMixin, Test
         self.assertNotContains(response, "Replaced a component")
 
 
-@tag("views", "ajax")
+@tag("views")
 class ProblemReportDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for ProblemReportDetailView AJAX text updates."""
 
@@ -493,7 +493,7 @@ class ProblemReportDetailLogEntriesTests(TestDataMixin, TestCase):
         self.assertContains(response, "No log entries yet")
 
 
-@tag("views", "ajax")
+@tag("views")
 class ProblemReportLogEntriesPartialViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for the log entries AJAX endpoint on problem report detail."""
 

--- a/the_flip/apps/maintenance/tests/test_problem_report_list.py
+++ b/the_flip/apps/maintenance/tests/test_problem_report_list.py
@@ -135,7 +135,7 @@ class ProblemReportListViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCa
         self.assertNotContains(response, "Other issue")
 
 
-@tag("views", "ajax")
+@tag("views")
 class ProblemReportListPartialViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for the problem report list AJAX endpoint."""
 

--- a/the_flip/apps/maintenance/tests/test_problem_report_media.py
+++ b/the_flip/apps/maintenance/tests/test_problem_report_media.py
@@ -16,7 +16,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.maintenance.models import ProblemReport, ProblemReportMedia
 
 
-@tag("views", "media")
+@tag("views")
 class ProblemReportMediaCreateTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Tests for media upload on problem report create page (maintainer)."""
 
@@ -95,7 +95,7 @@ class ProblemReportMediaCreateTests(TemporaryMediaMixin, TestDataMixin, TestCase
         mock_enqueue.assert_called_once_with(media_id=media.id, model_name="ProblemReportMedia")
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class ProblemReportMediaUploadTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -194,7 +194,7 @@ class ProblemReportMediaUploadTests(
         mock_enqueue.assert_called_once_with(media_id=media.id, model_name="ProblemReportMedia")
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class ProblemReportMediaDeleteTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -292,7 +292,7 @@ class ProblemReportMediaDeleteTests(
         self.assertTrue(ProblemReportMedia.objects.filter(pk=other_media.pk).exists())
 
 
-@tag("views", "media")
+@tag("views")
 class ProblemReportDetailMediaDisplayTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Tests for media display on problem report detail page."""
 

--- a/the_flip/apps/maintenance/tests/test_qr_codes.py
+++ b/the_flip/apps/maintenance/tests/test_qr_codes.py
@@ -9,7 +9,7 @@ from the_flip.apps.core.test_utils import (
 )
 
 
-@tag("views", "access-control")
+@tag("views")
 class MachineBulkQRCodeViewAccessTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for MachineBulkQRCodeView access control.
 

--- a/the_flip/apps/maintenance/tests/test_tasks.py
+++ b/the_flip/apps/maintenance/tests/test_tasks.py
@@ -16,7 +16,7 @@ from the_flip.apps.maintenance.models import LogEntry, LogEntryMedia
 TEST_TOKEN = secrets.token_hex(16)
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class GetTranscodingConfigTests(TestCase):
     """Tests for _get_transcoding_config helper."""
 
@@ -75,7 +75,7 @@ class GetTranscodingConfigTests(TestCase):
         self.assertEqual(token, "env-token")
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class SleepWithBackoffTests(TestCase):
     """Tests for _sleep_with_backoff helper."""
 
@@ -112,7 +112,7 @@ class SleepWithBackoffTests(TestCase):
         self.assertIn("connection refused", str(context.exception))
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class UploadTranscodedFilesTests(TestCase):
     """Tests for _upload_transcoded_files helper."""
 
@@ -248,7 +248,7 @@ class UploadTranscodedFilesTests(TestCase):
         self.assertEqual(mock_post.call_count, 3)
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class DownloadSourceFileTests(TestCase):
     """Tests for _download_source_file helper."""
 
@@ -422,7 +422,7 @@ class VideoMediaTestMixin:
         )
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class TranscodeVideoJobTests(VideoMediaTestMixin, TemporaryMediaMixin, TestCase):
     """Tests for transcode_video_job task."""
 
@@ -550,7 +550,7 @@ class TranscodeVideoJobTests(VideoMediaTestMixin, TemporaryMediaMixin, TestCase)
         self.assertEqual(statuses_during_run[0], LogEntryMedia.TranscodeStatus.PROCESSING)
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class TranscodeVideoErrorHandlingTests(VideoMediaTestMixin, TemporaryMediaMixin, TestCase):
     """Tests for transcode error handling."""
 
@@ -644,7 +644,7 @@ class TranscodeVideoErrorHandlingTests(VideoMediaTestMixin, TemporaryMediaMixin,
         upload.assert_called_once()
 
 
-@tag("tasks", "unit")
+@tag("tasks")
 class EnqueueTranscodeTests(TemporaryMediaMixin, TestCase):
     """Tests for enqueue_transcode helper."""
 

--- a/the_flip/apps/parts/tests/test_feature_flags.py
+++ b/the_flip/apps/parts/tests/test_feature_flags.py
@@ -10,7 +10,7 @@ from the_flip.apps.core.test_utils import (
 )
 
 
-@tag("feature_flags")
+@tag("views")
 class PartsFeatureFlagTests(TestDataMixin, TestCase):
     """Tests for the PARTS_ENABLED feature flag."""
 

--- a/the_flip/apps/parts/tests/test_part_request_detail.py
+++ b/the_flip/apps/parts/tests/test_part_request_detail.py
@@ -34,7 +34,7 @@ class PartRequestDetailViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCa
         self.assertContains(response, "Test part request")
 
 
-@tag("views", "ajax")
+@tag("views")
 class PartRequestDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for PartRequestDetailView AJAX text updates."""
 
@@ -93,7 +93,7 @@ class PartRequestDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestDataMix
         self.assertEqual(response.status_code, 403)
 
 
-@tag("views", "ajax")
+@tag("views")
 class PartRequestUpdateDetailViewTextUpdateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for PartRequestUpdateDetailView AJAX text updates."""
 

--- a/the_flip/apps/parts/tests/test_part_request_media.py
+++ b/the_flip/apps/parts/tests/test_part_request_media.py
@@ -16,7 +16,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.parts.models import PartRequest, PartRequestMedia
 
 
-@tag("views", "media")
+@tag("views")
 class PartRequestMediaCreateTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Tests for media upload on part request create page."""
 
@@ -81,7 +81,7 @@ class PartRequestMediaCreateTests(TemporaryMediaMixin, TestDataMixin, TestCase):
         mock_enqueue.assert_called_once_with(media_id=media.id, model_name="PartRequestMedia")
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class PartRequestMediaUploadTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -203,7 +203,7 @@ class PartRequestMediaUploadTests(
         mock_enqueue.assert_not_called()
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class PartRequestMediaDeleteTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -301,7 +301,7 @@ class PartRequestMediaDeleteTests(
         self.assertTrue(PartRequestMedia.objects.filter(pk=other_media.pk).exists())
 
 
-@tag("views", "media")
+@tag("views")
 class PartRequestDetailMediaDisplayTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Tests for media display on part request detail page."""
 

--- a/the_flip/apps/parts/tests/test_part_request_status.py
+++ b/the_flip/apps/parts/tests/test_part_request_status.py
@@ -11,7 +11,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.parts.models import PartRequest, PartRequestUpdate
 
 
-@tag("views", "ajax")
+@tag("views")
 class PartRequestStatusUpdateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for PartRequestStatusUpdateView AJAX endpoint."""
 

--- a/the_flip/apps/parts/tests/test_part_request_update_list.py
+++ b/the_flip/apps/parts/tests/test_part_request_update_list.py
@@ -11,7 +11,7 @@ from the_flip.apps.core.test_utils import (
 )
 
 
-@tag("views", "ajax")
+@tag("views")
 class PartRequestUpdatesPartialViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
     """Tests for PartRequestUpdatesPartialView AJAX infinite scroll endpoint."""
 

--- a/the_flip/apps/parts/tests/test_part_request_update_media.py
+++ b/the_flip/apps/parts/tests/test_part_request_update_media.py
@@ -17,7 +17,7 @@ from the_flip.apps.core.test_utils import (
 from the_flip.apps.parts.models import PartRequestUpdate, PartRequestUpdateMedia
 
 
-@tag("views", "media")
+@tag("views")
 class PartRequestUpdateMediaCreateTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Tests for media upload on part request update create page."""
 
@@ -89,7 +89,7 @@ class PartRequestUpdateMediaCreateTests(TemporaryMediaMixin, TestDataMixin, Test
         mock_enqueue.assert_called_once_with(media_id=media.id, model_name="PartRequestUpdateMedia")
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class PartRequestUpdateMediaUploadTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -216,7 +216,7 @@ class PartRequestUpdateMediaUploadTests(
         mock_enqueue.assert_not_called()
 
 
-@tag("views", "ajax", "media")
+@tag("views")
 class PartRequestUpdateMediaDeleteTests(
     TemporaryMediaMixin, SuppressRequestLogsMixin, TestDataMixin, TestCase
 ):
@@ -320,7 +320,7 @@ class PartRequestUpdateMediaDeleteTests(
         self.assertTrue(PartRequestUpdateMedia.objects.filter(pk=other_media.pk).exists())
 
 
-@tag("views", "media")
+@tag("views")
 class PartRequestUpdateDetailMediaDisplayTests(TemporaryMediaMixin, TestDataMixin, TestCase):
     """Tests for media display on part request update detail page."""
 


### PR DESCRIPTION
## Summary
- Standardized all test classes to use exactly 6 core tags, removing granular/combination tags that added noise without practical value
- Added missing `@tag` decorators to discord tests and core/tests.py
- Updated `docs/Testing.md` to document only the 6 approved tags

## The 6 Core Tags

| Tag | Use For | When to Run |
|-----|---------|-------------|
| `models` | Model/queryset logic, signals, managers | Editing models, managers, signals |
| `views` | HTTP request/response tests | Editing views, templates, URLs |
| `forms` | Form validation logic | Editing form classes |
| `tasks` | Background job tests (Django Q) | Editing async tasks |
| `admin` | Django admin customizations | Editing admin.py |
| `integration` | Tests requiring external services (ffmpeg, S3) | Exclude for fast local runs |

## What Changed
- Removed granular tags: `ajax`, `media`, `public`, `terminals`, `registration`, `access-control`, `security`, `ui`, `auth`, `feature_flags`, `environment`, `signals`, `unit`, `api`, `templatetags`
- Simplified multi-tag combinations (e.g., `@tag("views", "ajax")` → `@tag("views")`)

## Test plan
- [x] All 590 tests pass
- [x] Tag filtering works (verified: models=86, views=431, tasks=52, forms=18, admin=3)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified test tagging scheme from 14 to 6 categories for improved test organization and faster local execution.
  * Updated testing documentation with clearer guidance on test categorization and execution commands.

* **Tests**
  * Consolidated test tags across the test suite to align with the new streamlined tagging system, enhancing consistency without affecting test functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->