### PR TITLE
Upgrade to psycopg3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-decouple==3.8
 django-constance[database]==4.3.4
 
 # Database
-psycopg2-binary==2.9.11
+psycopg[binary]==3.3.2
 dj-database-url==3.0.1
 
 # Production Server
@@ -37,6 +37,6 @@ django-ipware==7.0.1
 
 # Discord Bot
 discord.py==2.6.4
-audioop-lts==0.2.1  # Python 3.13 compatibility for discord.py
+audioop-lts==0.2.2  # Python 3.13 compatibility for discord.py
 httpx==0.28.1
 anthropic


### PR DESCRIPTION
## Summary
- Replace psycopg2-binary 2.9.11 with psycopg 3.3.2
- Bump audioop-lts from 0.2.1 to 0.2.2

## Why
psycopg3 is the modern PostgreSQL adapter with native async support and active development. Django 6.0 prefers it and plans to deprecate psycopg2 in a future release. Migrating now prepares us for the eventual Django 6 upgrade.

## Test plan
- [x] All 592 tests pass
- [x] Start dev server, verify basic CRUD operations
- [x] Start background worker, verify video transcoding
- [ ] Start Discord bot, verify it connects (tests audioop-lts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database driver package to the latest version for improved database connectivity and enhanced performance.
  * Updated Python 3.13 compatibility dependency for better platform stability across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->