### PR TITLE
Add media delete confirmation

### DIFF
--- a/the_flip/static/core/media_grid.js
+++ b/the_flip/static/core/media_grid.js
@@ -284,6 +284,10 @@
     if (!button) return;
 
     button.addEventListener('click', async () => {
+      if (!confirm('Delete?')) {
+        return;
+      }
+
       const mediaId = button.dataset.mediaId;
 
       const formData = new FormData();


### PR DESCRIPTION
## Summary
It was too easy to delete media (photos and videos) from records.  This adds a confirmation dialog when clicking the delete button on media items, to prevent accidental deletion of photos and videos.

## Test plan
- [x] Click delete button on a media item → confirmation dialog appears
- [x] Click Cancel or press Escape → media is not deleted
- [x] Click OK or press Enter → media is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user confirmation step before media deletion. If canceled, the delete action is aborted; otherwise, deletion proceeds as normal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->