### PR TITLE
feat(catalog): article-aware alphabetical sorting for machines

### DIFF
--- a/flipfix/apps/catalog/admin.py
+++ b/flipfix/apps/catalog/admin.py
@@ -23,7 +23,7 @@ class MachineModelAdmin(SimpleHistoryAdmin):
     search_fields = ("name", "slug", "manufacturer", "ipdb_id")
     list_filter = ("era", "manufacturer")
     prepopulated_fields = {"slug": ("name",)}
-    readonly_fields = ("created_by", "updated_by")
+    readonly_fields = ("sort_name", "created_by", "updated_by")
 
 
 @admin.register(MachineInstance)

--- a/flipfix/apps/catalog/apps.py
+++ b/flipfix/apps/catalog/apps.py
@@ -42,7 +42,7 @@ class CatalogConfig(AppConfig):
                 url_kwarg="slug",
                 url_field="slug",
                 autocomplete_search_fields=("name", "model__name", "model__manufacturer", "slug"),
-                autocomplete_ordering=("model__name",),
+                autocomplete_ordering=("model__sort_name",),
                 autocomplete_select_related=("model",),
                 autocomplete_serialize=_serialize_machine,
                 sort_order=20,
@@ -60,7 +60,7 @@ class CatalogConfig(AppConfig):
                 url_kwarg="slug",
                 url_field="slug",
                 autocomplete_search_fields=("name", "manufacturer", "slug"),
-                autocomplete_ordering=("name",),
+                autocomplete_ordering=("sort_name",),
                 autocomplete_serialize=_serialize_model,
                 sort_order=70,
             )

--- a/flipfix/apps/catalog/migrations/0015_machinemodel_sort_name.py
+++ b/flipfix/apps/catalog/migrations/0015_machinemodel_sort_name.py
@@ -9,10 +9,13 @@ def backfill_sort_name(apps, schema_editor):
     """Populate sort_name for all existing MachineModel rows."""
     MachineModel = apps.get_model("catalog", "MachineModel")
     pattern = re.compile(r"^(The|A|An)\s+", re.IGNORECASE)
-    for obj in MachineModel.objects.all():
+    batch = []
+    for obj in MachineModel.objects.only("name").iterator(chunk_size=500):
         stripped = pattern.sub("", obj.name)
         obj.sort_name = stripped if stripped else obj.name
-        obj.save(update_fields=["sort_name"])
+        batch.append(obj)
+    if batch:
+        MachineModel.objects.bulk_update(batch, ["sort_name"])
 
 
 def reverse_backfill(apps, schema_editor):

--- a/flipfix/apps/catalog/migrations/0015_machinemodel_sort_name.py
+++ b/flipfix/apps/catalog/migrations/0015_machinemodel_sort_name.py
@@ -1,0 +1,58 @@
+"""Add sort_name field to MachineModel for article-aware alphabetical sorting."""
+
+import re
+
+from django.db import migrations, models
+
+
+def backfill_sort_name(apps, schema_editor):
+    """Populate sort_name for all existing MachineModel rows."""
+    MachineModel = apps.get_model("catalog", "MachineModel")
+    pattern = re.compile(r"^(The|A|An)\s+", re.IGNORECASE)
+    for obj in MachineModel.objects.all():
+        stripped = pattern.sub("", obj.name)
+        obj.sort_name = stripped if stripped else obj.name
+        obj.save(update_fields=["sort_name"])
+
+
+def reverse_backfill(apps, schema_editor):
+    """Clear sort_name (field will be dropped by reverse AddField)."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("catalog", "0014_name_not_null"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="machinemodel",
+            name="sort_name",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="Name with leading articles stripped, for alphabetical sorting",
+                max_length=200,
+            ),
+        ),
+        migrations.AddField(
+            model_name="historicalmachinemodel",
+            name="sort_name",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="Name with leading articles stripped, for alphabetical sorting",
+                max_length=200,
+            ),
+        ),
+        migrations.RunPython(backfill_sort_name, reverse_backfill),
+        migrations.AlterModelOptions(
+            name="machinemodel",
+            options={"ordering": ["sort_name"]},
+        ),
+        migrations.AlterModelOptions(
+            name="machineinstance",
+            options={"ordering": ["model__sort_name", "serial_number"]},
+        ),
+    ]

--- a/flipfix/apps/catalog/models.py
+++ b/flipfix/apps/catalog/models.py
@@ -12,6 +12,7 @@ from model_utils import FieldTracker
 from simple_history.models import HistoricalRecords
 
 from flipfix.apps.core.models import TimeStampedMixin
+from flipfix.apps.core.text import strip_leading_articles
 
 
 class Location(models.Model):
@@ -120,6 +121,12 @@ class MachineModel(TimeStampedMixin):
     sources_notes = models.TextField(
         blank=True, help_text="Notes about data sources and references"
     )
+    sort_name = models.CharField(
+        max_length=200,
+        blank=True,
+        db_index=True,
+        help_text="Name with leading articles stripped, for alphabetical sorting",
+    )
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
@@ -138,7 +145,7 @@ class MachineModel(TimeStampedMixin):
     history = HistoricalRecords()
 
     class Meta:
-        ordering = ["name"]
+        ordering = ["sort_name"]
 
     def __str__(self) -> str:
         return self.name
@@ -148,6 +155,7 @@ class MachineModel(TimeStampedMixin):
         return reverse("admin:catalog_machinemodel_history", args=[self.pk])
 
     def save(self, *args, **kwargs):
+        self.sort_name = strip_leading_articles(self.name)
         if not self.slug:
             base_slug = slugify(self.name) or "model"
             slug = base_slug
@@ -261,7 +269,7 @@ class MachineInstance(TimeStampedMixin):
     tracker = FieldTracker(fields=["operational_status", "location_id"])
 
     class Meta:
-        ordering = ["model__name", "serial_number"]
+        ordering = ["model__sort_name", "serial_number"]
 
     def __str__(self) -> str:
         return self.name

--- a/flipfix/apps/catalog/tests/test_machine_models.py
+++ b/flipfix/apps/catalog/tests/test_machine_models.py
@@ -26,6 +26,38 @@ class MachineModelTests(TestCase):
 
 
 @tag("models")
+class MachineModelSortNameTests(TestCase):
+    """Tests for the sort_name field on MachineModel."""
+
+    def test_sort_name_populated_on_create(self):
+        """sort_name should be set automatically from name on create."""
+        model = MachineModel.objects.create(name="The Addams Family")
+        self.assertEqual(model.sort_name, "Addams Family")
+
+    def test_sort_name_updated_on_rename(self):
+        """sort_name should update when name changes."""
+        model = MachineModel.objects.create(name="The Addams Family")
+        model.name = "Monster Bash"
+        model.save()
+        model.refresh_from_db()
+        self.assertEqual(model.sort_name, "Monster Bash")
+
+    def test_sort_name_no_article(self):
+        """Names without leading articles should have sort_name == name."""
+        model = MachineModel.objects.create(name="Monster Bash")
+        self.assertEqual(model.sort_name, "Monster Bash")
+
+    def test_default_ordering_uses_sort_name(self):
+        """Default queryset ordering should sort by sort_name (article-stripped)."""
+        MachineModel.objects.create(name="The Addams Family")
+        MachineModel.objects.create(name="Monster Bash")
+        MachineModel.objects.create(name="Attack From Mars")
+
+        names = list(MachineModel.objects.values_list("name", flat=True))
+        self.assertEqual(names, ["The Addams Family", "Attack From Mars", "Monster Bash"])
+
+
+@tag("models")
 class MachineInstanceModelTests(TestCase):
     """Tests for the MachineInstance model."""
 

--- a/flipfix/apps/catalog/views.py
+++ b/flipfix/apps/catalog/views.py
@@ -74,9 +74,8 @@ class MachineListView(ListView):
                 ),
                 # 2. Machines with open problem reports first (nulls last means machines with no reports come last)
                 F("latest_open_report_date").desc(nulls_last=True),
-                # 3. Within machines with open reports, sort by most recent report first (already handled by step 2)
-                # 4. Machine name as tie-breaker
-                Lower("model__name"),
+                # 3. Machine name as tie-breaker
+                Lower("model__sort_name"),
             )
         )
 
@@ -264,7 +263,7 @@ class MachineCreateLandingView(View):
     template_name = "catalog/machine_create_landing.html"
 
     def get(self, request):
-        context = {"models": MachineModel.objects.all().order_by("name")}
+        context = {"models": MachineModel.objects.all().order_by("sort_name")}
         return TemplateResponse(request, self.template_name, context)
 
     def post(self, request):

--- a/flipfix/apps/core/tests/test_text.py
+++ b/flipfix/apps/core/tests/test_text.py
@@ -1,0 +1,49 @@
+"""Tests for core text utilities."""
+
+from django.test import TestCase, tag
+
+from flipfix.apps.core.text import strip_leading_articles
+
+
+@tag("unit")
+class StripLeadingArticlesTests(TestCase):
+    """Tests for strip_leading_articles()."""
+
+    def test_strips_the(self):
+        self.assertEqual(strip_leading_articles("The Addams Family"), "Addams Family")
+
+    def test_strips_a(self):
+        self.assertEqual(strip_leading_articles("A New Machine"), "New Machine")
+
+    def test_strips_an(self):
+        self.assertEqual(strip_leading_articles("An Old Game"), "Old Game")
+
+    def test_case_insensitive(self):
+        self.assertEqual(strip_leading_articles("the addams family"), "addams family")
+        self.assertEqual(strip_leading_articles("THE ADDAMS FAMILY"), "ADDAMS FAMILY")
+
+    def test_no_op_aerosmith(self):
+        """'Aerosmith' should not be affected — 'A' needs a trailing space."""
+        self.assertEqual(strip_leading_articles("Aerosmith"), "Aerosmith")
+
+    def test_no_op_andromeda(self):
+        """'Andromeda' should not be affected — 'An' needs a trailing space."""
+        self.assertEqual(strip_leading_articles("Andromeda"), "Andromeda")
+
+    def test_no_op_theatre_of_magic(self):
+        """'Theatre of Magic' should not be affected — 'The' needs exact match."""
+        self.assertEqual(strip_leading_articles("Theatre of Magic"), "Theatre of Magic")
+
+    def test_empty_string(self):
+        self.assertEqual(strip_leading_articles(""), "")
+
+    def test_name_is_just_the_article(self):
+        """If the name is just 'The', return it unchanged."""
+        self.assertEqual(strip_leading_articles("The"), "The")
+
+    def test_no_article(self):
+        self.assertEqual(strip_leading_articles("Monster Bash"), "Monster Bash")
+
+    def test_article_only_stripped_from_start(self):
+        """Articles in the middle of the name should not be stripped."""
+        self.assertEqual(strip_leading_articles("Escape The Room"), "Escape The Room")

--- a/flipfix/apps/core/text.py
+++ b/flipfix/apps/core/text.py
@@ -1,0 +1,15 @@
+"""Text utilities for the core app."""
+
+import re
+
+_LEADING_ARTICLE_RE = re.compile(r"^(The|A|An)\s+", re.IGNORECASE)
+
+
+def strip_leading_articles(name: str) -> str:
+    """Strip leading English articles ('The', 'A', 'An') for sorting purposes.
+
+    Returns the original name if stripping would produce an empty string
+    (e.g. the name is just "The").
+    """
+    result = _LEADING_ARTICLE_RE.sub("", name)
+    return result if result else name

--- a/flipfix/apps/maintenance/views/autocomplete.py
+++ b/flipfix/apps/maintenance/views/autocomplete.py
@@ -87,7 +87,7 @@ class MachineAutocompleteView(View):
                     output_field=IntegerField(),
                 ),
                 F("latest_open_report_date").desc(nulls_last=True),
-                Lower("model__name"),
+                Lower("model__sort_name"),
             )
         )
 


### PR DESCRIPTION
## Summary

- Adds a `sort_name` field to `MachineModel` that strips leading English articles ("The", "A", "An") for alphabetical sorting
- Auto-populated on `save()`, with a data migration to backfill existing rows
- Updates `Meta.ordering`, all explicit `order_by` calls, and autocomplete ordering across the app
- "The Addams Family" now sorts under "A", not "T"

## Test plan

- [x] 1566 existing tests pass
- [x] 15 new tests: `strip_leading_articles` utility (11) + `MachineModel.sort_name` behavior and default ordering (4)
- [x] `make quality` clean (ruff, djlint, mypy)
- [x] Migration applies cleanly
- [x] Manual: `/machines/` list shows "The Addams Family" sorted under A
- [x] Manual: machine autocomplete sorts article-stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an article-stripped sort key so names are sorted without leading articles (The, A, An).

* **Bug Fixes**
  * Improved alphabetical ordering across the app: lists, default orderings, autocomplete dropdowns, tie-breakers, and model selector now use article-stripped names for more intuitive results.

* **Tests**
  * Added tests to verify article stripping and the resulting default ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->