### PR TITLE
chore: bump django, pillow, requests for security CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Django Web Framework
-Django==5.2.12
+Django==5.2.14
 
 # Configuration Management
 python-decouple==3.8
@@ -17,11 +17,11 @@ whitenoise==6.11.0
 
 # QR Code Generation
 qrcode[pil]==8.2
-Pillow==12.1.1
+Pillow==12.2.0
 django-q2==1.9.0
 
 # HTTP Requests (for worker → web service transfer)
-requests==2.32.5
+requests==2.33.0
 
 # Markdown Rendering
 markdown-it-py==4.0.0


### PR DESCRIPTION
## Summary

Resolves 14 pip-audit vulnerabilities flagged by CI.

- Django 5.2.12 → 5.2.14 (8 CVEs, all patch-level within 5.2.x)
- Pillow 12.1.1 → 12.2.0 (5 CVEs)
- requests 2.32.5 → 2.33.0 (1 CVE)

## Test plan

- [x] `make test` passes (1696 tests)
- [ ] CI `pip-audit` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)