### PR TITLE
feat(markdown): enable [[user:username]] wikilinking

### DIFF
--- a/docs/MarkdownLinks.md
+++ b/docs/MarkdownLinks.md
@@ -29,7 +29,7 @@ The system supports two kinds of link types:
 - **Slug-based** (e.g., `[[machine:blackout]]`): For models with human-readable slugs. The authoring format uses the slug, while the storage format uses the database PK (`[[machine:id:42]]`).
 - **ID-based** (e.g., `[[problem:7]]`): For models without slugs. The format is the same in both authoring and storage.
 
-Seven link types are registered across four apps:
+Eight link types are registered across five apps:
 
 | Type                | App         | Format     | Model               |
 | ------------------- | ----------- | ---------- | ------------------- |
@@ -40,6 +40,9 @@ Seven link types are registered across four apps:
 | `partrequest`       | parts       | ID-based   | `PartRequest`       |
 | `partrequestupdate` | parts       | ID-based   | `PartRequestUpdate` |
 | `page`              | wiki        | slug-based | `WikiPageTag`       |
+| `user`              | accounts    | slug-based | `auth.User`         |
+
+The `user` type is scoped to directory-visible maintainers — see [`Scoping`](#scoping) for how `target_queryset` keeps autocomplete, save-time validation, render-time resolution, and reference syncing all in agreement about which targets are linkable.
 
 ### Registry pattern
 
@@ -176,6 +179,20 @@ See `core/tests/test_link_rendering.py`, `core/tests/test_link_conversion.py`, a
 | ------------ | ------- | --------------------------------------------------------------------------- |
 | `slug_field` | `None`  | Set to the model's slug field name for slug-based types. `None` = ID-based. |
 
+#### Scoping
+
+`target_queryset` defines the set of records a link type considers linkable. It is a callable `(model) -> QuerySet` that defaults to `model.objects.all()`. The same scope is used by save-time conversion, render-time lookup, autocomplete, and reference syncing — all in agreement.
+
+Use it when a record exists in the database but should not be linkable — e.g. the `user` type uses it to scope to directory-visible maintainers so deactivated users, shared kiosk accounts, and orphan users without a profile page are hidden from `[[user:…]]`.
+
+Records outside the scope behave exactly like deleted records:
+
+- Autocomplete does not surface them.
+- `convert_authoring_to_storage("[[type:slug]]")` raises `ValidationError`.
+- Render output for `[[type:id:N]]` is `*[broken link]*`.
+- `convert_storage_to_authoring("[[type:id:N]]")` leaves the storage token unchanged — the edit form shows the raw token so the author can decide what to do. Broken-link text is strictly a render-time concern.
+- `sync_references()` prunes the `RecordReference` row on the next save (and recreates it if the record re-enters scope — self-healing).
+
 **Rendering (in markdown output):**
 
 | Field            | Default  | Description                                                |
@@ -208,9 +225,13 @@ Most slug-based types don't need these — the defaults use `slug_field` directl
 
 **Other:**
 
-| Field        | Default        | Description                                                            |
-| ------------ | -------------- | ---------------------------------------------------------------------- |
-| `is_enabled` | `lambda: True` | Runtime toggle. Return `False` to hide the type without unregistering. |
+| Field        | Default        | Description                                                                         |
+| ------------ | -------------- | ----------------------------------------------------------------------------------- |
+| `is_enabled` | `lambda: True` | Runtime toggle. Return `False` to hide the type without unregistering.              |
+| `sort_order` | `100`          | Integer controlling position in the `[[` type picker — lower numbers appear higher. |
+
+Existing `sort_order` values, for reference when slotting a new type:
+`page` (10), `machine` (20), `problem` (30), `log` (40), `partrequest` (50), `partrequestupdate` (60), `model` (70), `user` (80).
 
 ## Adding a New Link Source
 
@@ -338,6 +359,7 @@ if action == "update_text":
 | Simple ID-based type                      | `maintenance/apps.py` → `problem` registration                                    |
 | ID-based with related model in label      | `parts/apps.py` → `partrequestupdate` registration                                |
 | Irregular slug format (e.g., `tag/slug`)  | `wiki/apps.py` → `page` registration                                              |
+| Scoped link target (filter linkable rows) | `accounts/apps.py` → `user` registration (uses `target_queryset`)                 |
 | ModelForm source with `save(commit=True)` | `maintenance/forms.py` → `MaintainerProblemReportForm`                            |
 | Regular Form source (sync in view)        | `maintenance/forms.py` → `LogEntryQuickForm` + `maintenance/views/log_entries.py` |
 | Signal cleanup                            | `maintenance/apps.py` → `register_reference_cleanup()` call                       |

--- a/flipfix/apps/accounts/apps.py
+++ b/flipfix/apps/accounts/apps.py
@@ -13,3 +13,52 @@ class AccountsConfig(AppConfig):
         from .models import MaintainerMedia
 
         register_media_model(MaintainerMedia)
+        self._register_link_types()
+
+    @staticmethod
+    def _register_link_types() -> None:
+        # Imports go inside ready()-called methods so the app registry is
+        # fully loaded before we touch other apps' models.
+        from django.db.models import F, Value
+        from django.db.models.functions import Coalesce, Lower, NullIf
+
+        from flipfix.apps.accounts.display import display_name_with_username
+        from flipfix.apps.accounts.models import Maintainer
+        from flipfix.apps.core.markdown_links import LinkType, register
+
+        def _serialize_user(obj):
+            return {
+                "label": display_name_with_username(obj),
+                "ref": obj.username,
+            }
+
+        # Scope: directory-visible maintainers only. Routing through the
+        # existing queryset method keeps Maintainer.objects.in_user_directory()
+        # as the single source of truth — if that predicate changes, save-time
+        # validation, render-time resolution, and autocomplete all update.
+        def _directory_users(model):
+            return model.objects.filter(
+                pk__in=Maintainer.objects.in_user_directory().values("user_id"),
+            )
+
+        register(
+            LinkType(
+                name="user",
+                model_path="auth.User",
+                slug_field="username",
+                label="User",
+                description="Link to a user's profile",
+                url_name="user-profile",
+                url_kwarg="username",
+                url_field="username",
+                get_label=display_name_with_username,
+                target_queryset=_directory_users,
+                autocomplete_search_fields=("username", "first_name", "last_name"),
+                autocomplete_ordering=(
+                    F("maintainer__last_active_at").desc(nulls_last=True),
+                    Lower(Coalesce(NullIf("first_name", Value("")), "username")),
+                ),
+                autocomplete_serialize=_serialize_user,
+                sort_order=80,
+            )
+        )

--- a/flipfix/apps/accounts/display.py
+++ b/flipfix/apps/accounts/display.py
@@ -1,0 +1,30 @@
+"""Pure display helpers for User/Maintainer rendering.
+
+Kept template-tag-free so callers outside the template layer
+(e.g. ``AppConfig.ready()`` link-type registration) can import without
+pulling in permission filters or other template machinery.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def display_name_with_username(user: Any) -> str:
+    """Return user's display name with username suffix.
+
+    Returns ``"First Last (username)"`` when any name part is set,
+    ``"First (username)"`` or ``"Last (username)"`` when only one is set,
+    or the bare ``username`` when no name parts are set.
+
+    Returns the empty string when ``user`` is falsy.
+    """
+    if not user:
+        return ""
+    first = getattr(user, "first_name", "") or ""
+    last = getattr(user, "last_name", "") or ""
+    username = getattr(user, "username", "") or ""
+    if first or last:
+        full_name = f"{first} {last}".strip()
+        return f"{full_name} ({username})"
+    return username

--- a/flipfix/apps/accounts/forms.py
+++ b/flipfix/apps/accounts/forms.py
@@ -8,6 +8,7 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.password_validation import validate_password
 
 from flipfix.apps.core.forms import MarkdownTextarea, StyledFormMixin, clean_markdown_field
+from flipfix.apps.core.markdown_links import convert_storage_to_authoring
 
 from .models import RESERVED_USERNAMES, Maintainer
 
@@ -104,10 +105,17 @@ class MaintainerProfileForm(StyledFormMixin, forms.ModelForm):
             "bio": MarkdownTextarea(
                 attrs={
                     "rows": 4,
-                    "placeholder": "A short markdown bio.",
+                    "placeholder": "Your bio.  Supports markdown and [[ wikilinks.",
                 }
             ),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Render existing bios in authoring format so links show as
+        # ``[[user:alice]]`` rather than the stored ``[[user:id:N]]``.
+        if self.instance.pk and self.instance.bio:
+            self.initial["bio"] = convert_storage_to_authoring(self.instance.bio)
 
     def clean_bio(self):
         """Convert authoring-format ``[[links]]`` to storage format."""

--- a/flipfix/apps/accounts/templatetags/accounts_tags.py
+++ b/flipfix/apps/accounts/templatetags/accounts_tags.py
@@ -1,7 +1,16 @@
-"""Accounts domain: display_name_with_username, can_manage_catalog."""
+"""Accounts template filters.
+
+Thin wrappers exposing :mod:`flipfix.apps.accounts.display` and
+:mod:`flipfix.apps.accounts.permissions` helpers to templates. Keeping the
+filter definitions consistent (decorator-bound, single-line bodies) makes
+it easy to scan this module for the full list of accounts filters.
+"""
 
 from django import template
 
+from flipfix.apps.accounts.display import (
+    display_name_with_username as _display_name_with_username,
+)
 from flipfix.apps.accounts.permissions import (
     can_manage_catalog as _can_manage_catalog,
 )
@@ -13,6 +22,15 @@ from flipfix.apps.accounts.permissions import (
 )
 
 register = template.Library()
+
+
+@register.filter(name="display_name_with_username")
+def display_name_with_username(user) -> str:
+    """Return ``"First Last (username)"`` or just ``username``.
+
+    Single source of truth: :func:`flipfix.apps.accounts.display.display_name_with_username`.
+    """
+    return _display_name_with_username(user)
 
 
 @register.filter(name="can_manage_catalog")
@@ -45,25 +63,3 @@ def is_in_user_directory(user) -> bool:
     Used by ``/profile`` to decide whether to show the photo management section.
     """
     return _is_in_user_directory(user)
-
-
-@register.filter
-def display_name_with_username(user):
-    """Return user's display name with username suffix.
-
-    Returns "First Last (username)" if first or last name is set,
-    otherwise just "username".
-
-    Usage:
-        {{ user|display_name_with_username }}
-        {{ terminal.user|display_name_with_username }}
-    """
-    if not user:
-        return ""
-    first = getattr(user, "first_name", "") or ""
-    last = getattr(user, "last_name", "") or ""
-    username = getattr(user, "username", "") or ""
-    if first or last:
-        full_name = f"{first} {last}".strip()
-        return f"{full_name} ({username})"
-    return username

--- a/flipfix/apps/accounts/tests/test_display.py
+++ b/flipfix/apps/accounts/tests/test_display.py
@@ -1,0 +1,37 @@
+"""Tests for accounts.display helpers."""
+
+from types import SimpleNamespace
+
+from django.contrib.auth.models import User
+from django.test import SimpleTestCase, tag
+
+from flipfix.apps.accounts.display import display_name_with_username
+
+
+@tag("unit")
+class DisplayNameWithUsernameTests(SimpleTestCase):
+    """Format ``display_name_with_username`` produces for various inputs."""
+
+    def test_no_name_returns_bare_username(self):
+        user = SimpleNamespace(first_name="", last_name="", username="alice")
+        self.assertEqual(display_name_with_username(user), "alice")
+
+    def test_both_names_returns_full_with_username(self):
+        user = SimpleNamespace(first_name="Alice", last_name="Anderson", username="alice")
+        self.assertEqual(display_name_with_username(user), "Alice Anderson (alice)")
+
+    def test_first_name_only(self):
+        user = SimpleNamespace(first_name="Alice", last_name="", username="alice")
+        self.assertEqual(display_name_with_username(user), "Alice (alice)")
+
+    def test_last_name_only(self):
+        user = SimpleNamespace(first_name="", last_name="Anderson", username="alice")
+        self.assertEqual(display_name_with_username(user), "Anderson (alice)")
+
+    def test_none_user_returns_empty_string(self):
+        self.assertEqual(display_name_with_username(None), "")
+
+    def test_works_on_real_user_instance(self):
+        """Sanity check against the actual User model, not just duck types."""
+        user = User(username="bob", first_name="Bob", last_name="Brown")
+        self.assertEqual(display_name_with_username(user), "Bob Brown (bob)")

--- a/flipfix/apps/accounts/tests/test_profile_form.py
+++ b/flipfix/apps/accounts/tests/test_profile_form.py
@@ -26,6 +26,29 @@ class MaintainerProfileFormTests(TestCase):
         user.maintainer.refresh_from_db()
         self.assertEqual(user.maintainer.bio, "Hello, I fix pinball.")
 
+    def test_initial_bio_converts_storage_to_authoring(self):
+        """Stored ``[[type:id:N]]`` tokens become ``[[type:slug]]`` for editing.
+
+        Without this, every link in a saved bio leaks as raw storage syntax
+        in the textarea. Covers all slug-based link types via one pass.
+        """
+        from flipfix.apps.catalog.models import MachineInstance, MachineModel
+
+        model = MachineModel.objects.create(name="Blackout", slug="blackout")
+        machine = MachineInstance.objects.create(model=model, name="Blackout", slug="blackout")
+        alice = create_maintainer_user(username="alice")
+        alice.maintainer.bio = (
+            f"Working on [[machine:id:{machine.pk}]]. Thanks [[user:id:{alice.pk}]]."
+        )
+        alice.maintainer.save(update_fields=["bio"])
+
+        form = MaintainerProfileForm(instance=alice.maintainer)
+
+        self.assertEqual(
+            form.initial["bio"],
+            "Working on [[machine:blackout]]. Thanks [[user:alice]].",
+        )
+
     def test_clean_bio_rejects_unresolvable_authoring_links(self):
         """``clean_markdown_field`` hook runs on bio.
 

--- a/flipfix/apps/accounts/tests/test_user_link.py
+++ b/flipfix/apps/accounts/tests/test_user_link.py
@@ -1,0 +1,279 @@
+"""Tests for the ``user`` markdown link type and its directory scoping.
+
+The ``user`` link type targets ``auth.User`` but is scoped to maintainers
+visible in the user directory (active, in the Maintainers group, not a shared
+account). These tests lock down the contract that authoring, render, autocomplete,
+storage-to-authoring, and RecordReference syncing all agree on that scope.
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.test import TestCase, tag
+from django.urls import reverse
+from django.utils import timezone
+
+from flipfix.apps.accounts.models import Maintainer
+from flipfix.apps.core.markdown_links import (
+    convert_authoring_to_storage,
+    convert_storage_to_authoring,
+    render_all_links,
+    sync_references,
+)
+from flipfix.apps.core.models import RecordReference
+from flipfix.apps.core.test_utils import (
+    SuppressRequestLogsMixin,
+    TestDataMixin,
+    create_machine,
+    create_maintainer_user,
+    create_user,
+)
+from flipfix.apps.maintenance.models import LogEntry
+
+
+@tag("views")
+class UserLinkHappyPathTests(TestCase):
+    """Happy-path conversion and rendering for directory-visible users."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = create_maintainer_user(
+            username="alice", first_name="Alice", last_name="Anderson"
+        )
+        self.machine = create_machine()
+
+    def test_authoring_to_storage_converts_username_to_id(self):
+        result = convert_authoring_to_storage("Thanks [[user:alice]] for fixing.")
+
+        self.assertEqual(result, f"Thanks [[user:id:{self.user.pk}]] for fixing.")
+
+    def test_storage_to_authoring_round_trips_to_username(self):
+        result = convert_storage_to_authoring(f"Thanks [[user:id:{self.user.pk}]] for fixing.")
+
+        self.assertEqual(result, "Thanks [[user:alice]] for fixing.")
+
+    def test_render_uses_display_name_with_username(self):
+        result = render_all_links(f"[[user:id:{self.user.pk}]]")
+
+        url = reverse("user-profile", kwargs={"username": "alice"})
+        self.assertEqual(result, f"[Alice Anderson (alice)]({url})")
+
+    def test_render_uses_bare_username_when_no_name(self):
+        bare = create_maintainer_user(username="bare")
+        result = render_all_links(f"[[user:id:{bare.pk}]]")
+
+        url = reverse("user-profile", kwargs={"username": "bare"})
+        self.assertEqual(result, f"[bare]({url})")
+
+    def test_hard_deleted_user_renders_as_broken_link(self):
+        pk = self.user.pk
+        self.user.delete()
+
+        result = render_all_links(f"[[user:id:{pk}]]")
+
+        self.assertIn("*[broken link]*", result)
+
+
+@tag("views")
+class UserLinkAutocompleteTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
+    """Autocomplete API behavior for ``type=user``."""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("api-link-targets")
+
+    def test_returns_directory_visible_user(self):
+        self.client.force_login(self.maintainer_user)
+        alice = create_maintainer_user(username="alice", first_name="Alice")
+
+        response = self.client.get(self.url + "?type=user&q=alice")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        refs = [r["ref"] for r in data["results"]]
+        self.assertIn(alice.username, refs)
+
+    def test_result_shape_uses_username_ref_and_display_label(self):
+        self.client.force_login(self.maintainer_user)
+        alice = create_maintainer_user(username="alice", first_name="Alice", last_name="Anderson")
+
+        response = self.client.get(self.url + "?type=user&q=alice")
+
+        data = response.json()
+        match = next((r for r in data["results"] if r["ref"] == "alice"), None)
+        self.assertIsNotNone(match)
+        self.assertEqual(match["label"], "Alice Anderson (alice)")
+        self.assertEqual(match["ref"], alice.username)
+
+    def test_results_sort_by_recent_activity_then_alpha(self):
+        """Recently-active maintainers surface above less-active or never-seen
+        maintainers, and the alpha tiebreaker breaks ties among the never-seen.
+        Mirrors the user-directory sort so the [[ picker matches what users
+        see when browsing /users/.
+        """
+        self.client.force_login(self.maintainer_user)
+
+        now = timezone.now()
+        recent = create_maintainer_user(username="recent")
+        stale = create_maintainer_user(username="stale")
+        # "zoe" and "amy" stay never-seen (last_active_at=NULL) to verify
+        # the alpha tiebreaker among the never-active tail.
+        create_maintainer_user(username="zoe")
+        create_maintainer_user(username="amy")
+
+        Maintainer.objects.filter(user=recent).update(last_active_at=now)
+        Maintainer.objects.filter(user=stale).update(last_active_at=now - timedelta(days=30))
+
+        response = self.client.get(self.url + "?type=user&q=")
+        refs = [r["ref"] for r in response.json()["results"]]
+
+        # The four maintainers we created should appear in this relative order
+        # within the full result set. Filter to just our test users to avoid
+        # coupling to other directory members created by TestDataMixin.
+        ours = [ref for ref in refs if ref in {"recent", "stale", "amy", "zoe"}]
+        self.assertEqual(ours, ["recent", "stale", "amy", "zoe"])
+
+
+@tag("views")
+class UserLinkScopingTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
+    """Out-of-directory users are uniformly invisible to the user link type.
+
+    For each non-directory variant, assert the same contract across:
+    autocomplete API, save-time conversion, render-time resolution,
+    storage-to-authoring conversion, and RecordReference syncing.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.api_url = reverse("api-link-targets")
+        self.machine = create_machine()
+
+    # ------------------------------------------------------------------
+    # The four "out of scope" fixtures
+    # ------------------------------------------------------------------
+
+    def _inactive_user(self):
+        user = create_maintainer_user(username="inactive")
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+        return user
+
+    def _non_maintainer_user(self):
+        # Has a Maintainer profile but is not in the Maintainers group.
+        # Mirrors a user who's been demoted but not deleted.
+        user = create_user(username="exmaintainer")
+        Maintainer.objects.create(user=user)
+        return user
+
+    def _shared_account_user(self):
+        user = create_maintainer_user(username="kiosk")
+        Maintainer.objects.filter(user=user).update(is_shared_account=True)
+        return user
+
+    def _orphan_user(self):
+        # User row with no Maintainer profile, despite being in the
+        # Maintainers group — e.g. a hand-added user. The exclusion reason
+        # is the missing Maintainer row: ``in_user_directory()`` queries
+        # ``Maintainer.objects``, so a User without a Maintainer is invisible
+        # regardless of group membership.
+        user = create_user(username="orphan")
+        Group.objects.get(name="Maintainers").user_set.add(user)
+        return user
+
+    def _all_out_of_scope_users(self):
+        return [
+            ("inactive", self._inactive_user()),
+            ("non_maintainer", self._non_maintainer_user()),
+            ("shared_account", self._shared_account_user()),
+            ("orphan", self._orphan_user()),
+        ]
+
+    # ------------------------------------------------------------------
+    # Contract assertions
+    # ------------------------------------------------------------------
+
+    def test_autocomplete_excludes_out_of_scope_users(self):
+        self.client.force_login(self.maintainer_user)
+
+        for label, user in self._all_out_of_scope_users():
+            with self.subTest(case=label):
+                response = self.client.get(self.api_url + f"?type=user&q={user.username}")
+                refs = [r["ref"] for r in response.json()["results"]]
+                self.assertNotIn(user.username, refs)
+
+    def test_authoring_to_storage_raises_for_out_of_scope(self):
+        for label, user in self._all_out_of_scope_users():
+            with self.subTest(case=label):
+                with self.assertRaises(ValidationError) as ctx:
+                    convert_authoring_to_storage(f"Hi [[user:{user.username}]]")
+                self.assertIn("User not found", str(ctx.exception))
+
+    def test_render_treats_out_of_scope_as_broken_link(self):
+        for label, user in self._all_out_of_scope_users():
+            with self.subTest(case=label):
+                result = render_all_links(f"[[user:id:{user.pk}]]")
+                self.assertIn("*[broken link]*", result)
+
+    def test_storage_to_authoring_leaves_out_of_scope_token_unchanged(self):
+        """The critical invariant: storage→authoring refuses to materialise
+        an out-of-scope slug. The edit form shows the raw token so the
+        maintainer can decide what to do with it; broken-link text is
+        strictly a render-time concern.
+        """
+        for label, user in self._all_out_of_scope_users():
+            with self.subTest(case=label):
+                token = f"[[user:id:{user.pk}]]"
+                result = convert_storage_to_authoring(token)
+                self.assertEqual(result, token)
+                # Sanity: never produces broken-link text in authoring form
+                self.assertNotIn("[broken link]", result)
+
+    def test_sync_references_prunes_when_user_leaves_directory(self):
+        """RecordReference rows track the scoped target set. A directory-
+        visible user picks up a row when linked, and the row is pruned on
+        the next save once they leave the directory. Restoring directory
+        visibility re-creates the row (self-healing).
+        """
+        alice = create_maintainer_user(username="alice")
+        source = LogEntry.objects.create(machine=self.machine, text="placeholder")
+        content = f"Thanks [[user:id:{alice.pk}]]!"
+
+        # 1. Initial sync creates the row.
+        sync_references(source, content)
+        user_ct = ContentType.objects.get(app_label="auth", model="user")
+        self.assertTrue(
+            RecordReference.objects.filter(
+                source_type=ContentType.objects.get_for_model(source),
+                source_id=source.pk,
+                target_type=user_ct,
+                target_id=alice.pk,
+            ).exists()
+        )
+
+        # 2. Alice leaves the directory; same content re-syncs to nothing.
+        alice.is_active = False
+        alice.save(update_fields=["is_active"])
+        sync_references(source, content)
+        self.assertFalse(
+            RecordReference.objects.filter(
+                source_type=ContentType.objects.get_for_model(source),
+                source_id=source.pk,
+                target_type=user_ct,
+                target_id=alice.pk,
+            ).exists()
+        )
+
+        # 3. Restore alice; the row comes back on the next save.
+        alice.is_active = True
+        alice.save(update_fields=["is_active"])
+        sync_references(source, content)
+        self.assertTrue(
+            RecordReference.objects.filter(
+                source_type=ContentType.objects.get_for_model(source),
+                source_id=source.pk,
+                target_type=user_ct,
+                target_id=alice.pk,
+            ).exists()
+        )

--- a/flipfix/apps/core/markdown_links.py
+++ b/flipfix/apps/core/markdown_links.py
@@ -29,6 +29,7 @@ from typing import Any
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Q
+from django.db.models.expressions import Combinable
 
 # ---------------------------------------------------------------------------
 # LinkType dataclass
@@ -63,6 +64,14 @@ class LinkType:
     get_label: Callable[[Any], str] | None = None  # override for irregular label
     select_related: tuple[str, ...] = ()
 
+    # --- Scoping ---
+    # The set of records this link type considers linkable. Used by save-time
+    # conversion, render-time lookup, autocomplete, and reference syncing.
+    # Defaults to ``model.objects.all()``. Set to a callable to scope the type
+    # to a subset (e.g. only maintainers visible in the user directory) so
+    # records outside the scope render as broken links and won't autocomplete.
+    target_queryset: Callable[[type[models.Model]], models.QuerySet[Any]] | None = None
+
     # --- Authoring format (slug-based types only) ---
     # Custom lookup for authoring format: (model_class, raw_values) -> {key: obj}
     # Default for slug-based types: filter(**{slug_field + "__in": values})
@@ -75,7 +84,10 @@ class LinkType:
 
     # --- Autocomplete ---
     autocomplete_search_fields: tuple[str, ...] = ()
-    autocomplete_ordering: tuple[str, ...] = ()
+    # Strings or ORM expressions (``F``, ``OrderBy``, ``Lower``, …) — anything
+    # ``QuerySet.order_by()`` accepts. Expressions are necessary for nulls-last
+    # sorts and case-insensitive collation; bare strings are fine otherwise.
+    autocomplete_ordering: tuple[str | Combinable, ...] = ()
     autocomplete_select_related: tuple[str, ...] = ()
     autocomplete_serialize: Callable[[Any], dict] | None = None
 
@@ -106,6 +118,19 @@ class LinkType:
             return self.get_label(obj)
         return str(getattr(obj, self.label_field, obj))
 
+    def get_target_queryset(self) -> models.QuerySet[Any]:
+        """Return the queryset of records this link type considers linkable.
+
+        Defaults to ``model.objects.all()``. Types with a ``target_queryset``
+        callable use that instead — keeping save-time validation, render-time
+        resolution, autocomplete, and reference syncing all in agreement
+        about which targets are linkable.
+        """
+        model = self.get_model()
+        if self.target_queryset is None:
+            return model.objects.all()
+        return self.target_queryset(model)
+
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -119,6 +144,17 @@ def register(link_type: LinkType) -> None:
     """Register a link type. Called from each app's AppConfig.ready()."""
     if link_type.name in _registry:
         raise ValueError(f"Link type '{link_type.name}' is already registered")
+    # ``authoring_lookup`` bypasses ``get_target_queryset()`` in the slug-lookup
+    # paths (see ``_render_by_slug`` / ``_convert_to_storage``), so combining
+    # the two would silently break scoping at save time while still applying
+    # it at render time. Reject the combination at registration rather than
+    # leaving it as a latent trap.
+    if link_type.authoring_lookup is not None and link_type.target_queryset is not None:
+        raise ValueError(
+            f"Link type '{link_type.name}' sets both ``authoring_lookup`` and "
+            "``target_queryset``; these are mutually exclusive because "
+            "``authoring_lookup`` short-circuits the scope filter."
+        )
     _registry[link_type.name] = link_type
     # Compile regex patterns eagerly
     name = re.escape(link_type.name)
@@ -224,9 +260,8 @@ def _render_by_id(
     if not matches:
         return text
 
-    model = lt.get_model()
     ids = [int(m.group(1)) for m in matches]
-    qs = model.objects.filter(pk__in=ids)
+    qs = lt.get_target_queryset().filter(pk__in=ids)
     if lt.select_related:
         qs = qs.select_related(*lt.select_related)
     by_id = {obj.pk: obj for obj in qs}
@@ -261,7 +296,7 @@ def _render_by_slug(
     if lt.authoring_lookup:
         by_key = lt.authoring_lookup(model, raw_values)
     else:
-        qs = model.objects.filter(**{f"{lt.slug_field}__in": raw_values})
+        qs = lt.get_target_queryset().filter(**{f"{lt.slug_field}__in": raw_values})
         if lt.select_related:
             qs = qs.select_related(*lt.select_related)
         by_key = {getattr(obj, lt.slug_field): obj for obj in qs}
@@ -321,7 +356,7 @@ def _convert_to_storage(
     if lt.authoring_lookup:
         by_key = lt.authoring_lookup(model, raw_values)
     else:
-        qs = model.objects.filter(**{f"{lt.slug_field}__in": raw_values})
+        qs = lt.get_target_queryset().filter(**{f"{lt.slug_field}__in": raw_values})
         by_key = {getattr(obj, lt.slug_field): obj for obj in qs}
 
     result = content
@@ -362,9 +397,8 @@ def _convert_to_authoring(
     if not matches:
         return content
 
-    model = lt.get_model()
     ids = [int(m.group(1)) for m in matches]
-    by_id = {obj.pk: obj for obj in model.objects.filter(pk__in=ids)}
+    by_id = {obj.pk: obj for obj in lt.get_target_queryset().filter(pk__in=ids)}
 
     result = content
     for match in reversed(matches):
@@ -403,22 +437,23 @@ def sync_references(source: models.Model, content: str) -> None:
 
     content = content or ""
 
-    # Parse all link IDs from content using registered patterns
-    links_by_model: dict[type[Any], set[int]] = {}
+    # Parse all link IDs from content using registered patterns.
+    # Keyed by LinkType (not model) so each type's target_queryset is honored
+    # when validating which targets still exist. Types with no matches in
+    # content stay in the list so the loop below can prune stale refs whose
+    # content mention has disappeared.
+    links_by_type: list[tuple[LinkType, set[int]]] = []
     for lt in get_enabled_link_types():
         pats = get_patterns(lt)
         pattern = pats.get("storage") or pats.get("id")
         if pattern is None:
             continue
         ids = {int(m.group(1)) for m in pattern.finditer(content)}
-        links_by_model[lt.get_model()] = ids
-
-    if not links_by_model:
-        return
+        links_by_type.append((lt, ids))
 
     # Pre-compute all ContentTypes (single query via get_for_models)
     source_ct = ContentType.objects.get_for_model(source)
-    content_types = ContentType.objects.get_for_models(*links_by_model.keys())
+    content_types = ContentType.objects.get_for_models(*(lt.get_model() for lt, _ in links_by_type))
 
     # Get existing references for this source
     existing_refs = RecordReference.objects.filter(
@@ -431,7 +466,8 @@ def sync_references(source: models.Model, content: str) -> None:
     to_create: list[RecordReference] = []
     to_delete_filters: list[Q] = []
 
-    for model_class, target_ids in links_by_model.items():
+    for lt, target_ids in links_by_type:
+        model_class = lt.get_model()
         target_ct = content_types[model_class]
         existing_ids = existing_by_ct.get(target_ct.id, set())
 
@@ -441,8 +477,12 @@ def sync_references(source: models.Model, content: str) -> None:
                 to_delete_filters.append(Q(target_type=target_ct, target_id__in=existing_ids))
             continue
 
-        # Only reference targets that actually exist
-        valid_ids = set(model_class.objects.filter(pk__in=target_ids).values_list("pk", flat=True))
+        # Only reference in-scope targets. Out-of-scope IDs (e.g. a user no
+        # longer in the directory) get pruned the next time the source saves,
+        # keeping RecordReference in sync with what the renderer treats as live.
+        valid_ids = set(
+            lt.get_target_queryset().filter(pk__in=target_ids).values_list("pk", flat=True)
+        )
 
         # Refs to add
         for target_id in valid_ids - existing_ids:
@@ -455,8 +495,11 @@ def sync_references(source: models.Model, content: str) -> None:
                 )
             )
 
-        # Refs to remove
-        ids_to_remove = existing_ids - target_ids
+        # Refs to remove. Compare against valid_ids (not target_ids) so that
+        # existing rows whose target is no longer in scope — hard-deleted OR
+        # filtered out by target_queryset — get pruned, not just rows whose
+        # ID was removed from the source content.
+        ids_to_remove = existing_ids - valid_ids
         if ids_to_remove:
             to_delete_filters.append(Q(target_type=target_ct, target_id__in=ids_to_remove))
 

--- a/flipfix/apps/core/tests/test_link_conversion.py
+++ b/flipfix/apps/core/tests/test_link_conversion.py
@@ -186,3 +186,41 @@ class ReferenceSyncTests(TestCase):
         sync_references(entry, "See [[machine:id:99999]].")
 
         self.assertEqual(self._ref_count(entry, target_model=MachineInstance), 0)
+
+    def test_orphan_reference_pruned_when_target_hard_deleted(self):
+        """Re-syncing a source prunes orphan rows whose target was hard-deleted.
+
+        ``GenericForeignKey`` doesn't cascade on target deletion, so a target
+        hard-delete leaves the ``RecordReference`` row dangling. On the next
+        sync of any source that still mentions that ID, the orphan row is
+        cleaned up — keeping the "what links here" index in sync with what
+        the renderer treats as live.
+        """
+        entry = LogEntry.objects.create(machine=self.machine, text="test")
+        model = MachineModel.objects.create(name="Doomed", slug="doomed")
+        target = MachineInstance.objects.create(model=model, slug="doomed", name="Doomed")
+        content = f"See [[machine:id:{target.pk}]]."
+
+        # Set up the orphan: create the ref row, then hard-delete the target.
+        # No cleanup runs because ``register_reference_cleanup()`` only wires
+        # post_delete for *source* models, and ``GenericForeignKey`` doesn't
+        # cascade — so the ref row survives the target delete, reproducing
+        # the exact "orphan in the wild" state.
+        sync_references(entry, content)
+        self.assertTrue(self._ref_exists(entry, target))
+
+        target_pk = target.pk
+        MachineInstance.objects.filter(pk=target_pk).delete()
+        orphan_qs = RecordReference.objects.filter(
+            source_type=ContentType.objects.get_for_model(entry),
+            source_id=entry.pk,
+            target_type=ContentType.objects.get_for_model(MachineInstance),
+            target_id=target_pk,
+        )
+        self.assertTrue(
+            orphan_qs.exists(), "precondition: orphan row should remain after target hard-delete"
+        )
+
+        # Re-syncing the same content prunes the orphan.
+        sync_references(entry, content)
+        self.assertFalse(orphan_qs.exists())

--- a/flipfix/apps/core/tests/test_target_queryset_hook.py
+++ b/flipfix/apps/core/tests/test_target_queryset_hook.py
@@ -1,0 +1,204 @@
+"""Locks down the ``LinkType.target_queryset`` contract end-to-end.
+
+Independent of any specific app's link type, this test registers a fixture
+``LinkType`` with a scoping callable and asserts that all four touchpoints
+honor it: save-time conversion, render-time resolution, storage-to-authoring,
+and the autocomplete API. Future link types added with ``target_queryset``
+get this same contract for free.
+"""
+
+import uuid
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.test import TestCase, tag
+from django.urls import reverse
+
+from flipfix.apps.catalog.models import MachineInstance, MachineModel
+from flipfix.apps.core.markdown_links import (
+    LinkType,
+    _patterns,
+    _registry,
+    convert_authoring_to_storage,
+    convert_storage_to_authoring,
+    register,
+    render_all_links,
+    sync_references,
+)
+from flipfix.apps.core.models import RecordReference
+from flipfix.apps.core.test_utils import (
+    SuppressRequestLogsMixin,
+    TestDataMixin,
+)
+from flipfix.apps.maintenance.models import LogEntry
+
+# Prefix marks "in scope" for the fixture link type. A separate prefix is used
+# so the existing ``machine`` link type's targets stay disjoint from ours.
+IN_SCOPE_PREFIX = "scoped-"
+FIXTURE_LINK_NAME = "scopedmachine"
+
+
+def _serialize(obj):
+    return {"label": obj.name, "ref": obj.slug}
+
+
+def _in_scope_machines(model):
+    return model.objects.filter(slug__startswith=IN_SCOPE_PREFIX)
+
+
+def _register_fixture_link_type():
+    register(
+        LinkType(
+            name=FIXTURE_LINK_NAME,
+            model_path="catalog.MachineInstance",
+            slug_field="slug",
+            label="Scoped Machine",
+            description="Fixture link type for target_queryset contract tests",
+            url_name="maintainer-machine-detail",
+            url_kwarg="slug",
+            url_field="slug",
+            label_field="name",
+            target_queryset=_in_scope_machines,
+            autocomplete_search_fields=("name", "slug"),
+            autocomplete_ordering=("name",),
+            autocomplete_serialize=_serialize,
+            sort_order=999,
+        )
+    )
+
+
+def _unregister_fixture_link_type():
+    _registry.pop(FIXTURE_LINK_NAME, None)
+    _patterns.pop(FIXTURE_LINK_NAME, None)
+
+
+@tag("views")
+class TargetQuerysetHookTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
+    """End-to-end coverage of the ``target_queryset`` hook."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _register_fixture_link_type()
+        # Pair the cleanup with the setup so the unregister can't be lost
+        # if a future setUpClass step is added between them and raises.
+        cls.addClassCleanup(_unregister_fixture_link_type)
+
+    def setUp(self):
+        super().setUp()
+        suffix = uuid.uuid4().hex[:8]
+        self.model = MachineModel.objects.create(name=f"Model {suffix}", slug=f"model-{suffix}")
+        self.in_scope = MachineInstance.objects.create(
+            model=self.model,
+            name=f"In Scope {suffix}",
+            slug=f"{IN_SCOPE_PREFIX}{suffix}",
+        )
+        self.out_of_scope = MachineInstance.objects.create(
+            model=self.model,
+            name=f"Out Of Scope {suffix}",
+            slug=f"other-{suffix}",
+        )
+
+    # ------------------------------------------------------------------
+    # In-scope: behaves like a normal link type.
+    # ------------------------------------------------------------------
+
+    def test_in_scope_converts_authoring_to_storage(self):
+        content = f"See [[{FIXTURE_LINK_NAME}:{self.in_scope.slug}]]."
+        result = convert_authoring_to_storage(content)
+
+        self.assertEqual(result, f"See [[{FIXTURE_LINK_NAME}:id:{self.in_scope.pk}]].")
+
+    def test_in_scope_renders_as_link(self):
+        result = render_all_links(f"[[{FIXTURE_LINK_NAME}:id:{self.in_scope.pk}]]")
+
+        self.assertIn(self.in_scope.name, result)
+        self.assertIn("/machines/", result)
+
+    def test_in_scope_round_trips_through_storage(self):
+        result = convert_storage_to_authoring(f"[[{FIXTURE_LINK_NAME}:id:{self.in_scope.pk}]]")
+
+        self.assertEqual(result, f"[[{FIXTURE_LINK_NAME}:{self.in_scope.slug}]]")
+
+    def test_in_scope_appears_in_autocomplete(self):
+        self.client.force_login(self.maintainer_user)
+        url = reverse("api-link-targets")
+
+        response = self.client.get(url + f"?type={FIXTURE_LINK_NAME}&q={self.in_scope.slug}")
+
+        self.assertEqual(response.status_code, 200)
+        refs = [r["ref"] for r in response.json()["results"]]
+        self.assertIn(self.in_scope.slug, refs)
+
+    # ------------------------------------------------------------------
+    # Out-of-scope: hidden from the link surface at every layer.
+    # ------------------------------------------------------------------
+
+    def test_out_of_scope_authoring_raises_validation_error(self):
+        content = f"See [[{FIXTURE_LINK_NAME}:{self.out_of_scope.slug}]]."
+
+        with self.assertRaises(ValidationError):
+            convert_authoring_to_storage(content)
+
+    def test_out_of_scope_renders_as_broken_link(self):
+        result = render_all_links(f"[[{FIXTURE_LINK_NAME}:id:{self.out_of_scope.pk}]]")
+
+        self.assertIn("*[broken link]*", result)
+
+    def test_out_of_scope_storage_to_authoring_leaves_token_unchanged(self):
+        token = f"[[{FIXTURE_LINK_NAME}:id:{self.out_of_scope.pk}]]"
+
+        result = convert_storage_to_authoring(token)
+
+        self.assertEqual(result, token)
+
+    def test_out_of_scope_excluded_from_autocomplete(self):
+        self.client.force_login(self.maintainer_user)
+        url = reverse("api-link-targets")
+
+        response = self.client.get(url + f"?type={FIXTURE_LINK_NAME}&q={self.out_of_scope.slug}")
+
+        self.assertEqual(response.status_code, 200)
+        refs = [r["ref"] for r in response.json()["results"]]
+        self.assertNotIn(self.out_of_scope.slug, refs)
+
+    # ------------------------------------------------------------------
+    # sync_references: prunes rows that fall out of scope.
+    # ------------------------------------------------------------------
+
+    def test_sync_references_prunes_out_of_scope_target(self):
+        """When a previously in-scope target leaves the scope, an existing
+        RecordReference is pruned on the next sync — even though the
+        source content still mentions it.
+        """
+        source = LogEntry.objects.create(machine=self.machine, text="placeholder")
+        content = f"See [[{FIXTURE_LINK_NAME}:id:{self.in_scope.pk}]]."
+
+        sync_references(source, content)
+
+        source_ct = ContentType.objects.get_for_model(source)
+        target_ct = ContentType.objects.get_for_model(MachineInstance)
+        self.assertTrue(
+            RecordReference.objects.filter(
+                source_type=source_ct,
+                source_id=source.pk,
+                target_type=target_ct,
+                target_id=self.in_scope.pk,
+            ).exists()
+        )
+
+        # Move the target out of scope by renaming its slug.
+        MachineInstance.objects.filter(pk=self.in_scope.pk).update(
+            slug=f"out-of-scope-{self.in_scope.pk}"
+        )
+
+        sync_references(source, content)
+
+        self.assertFalse(
+            RecordReference.objects.filter(
+                source_type=source_ct,
+                source_id=source.pk,
+                target_type=target_ct,
+                target_id=self.in_scope.pk,
+            ).exists()
+        )

--- a/flipfix/apps/core/views/link_targets.py
+++ b/flipfix/apps/core/views/link_targets.py
@@ -47,8 +47,7 @@ class LinkTargetsView(View):
                 status=400,
             )
 
-        model = lt.get_model()
-        qs = model.objects.all()
+        qs = lt.get_target_queryset()
 
         if lt.autocomplete_select_related:
             qs = qs.select_related(*lt.autocomplete_select_related)


### PR DESCRIPTION
## Summary

Adds a `[[user:username]]` markdown link type.

- New `[[user:alice]]` syntax in any markdown field; autocomplete in the `[[` picker sorts by `Maintainer.last_active_at` (nulls last) with an alphabetical tiebreaker, matching the user directory's sort.
- Scoped to directory-visible maintainers
- `LinkType.target_queryset` callable lets a link type restrict its linkable set. The `user` type uses `Maintainer.objects.in_user_directory()` as the single source of truth — deactivated users, shared kiosk accounts, and orphan users without a profile are uniformly hidden from autocomplete, save-time validation, render-time resolution, and `RecordReference` syncing.
- `sync_references()` now also prunes orphan rows whose target was hard-deleted (latent bug fix: `GenericForeignKey` doesn't cascade and no signal cleanup is wired for target models).
- `register()` rejects the combination of `authoring_lookup` + `target_queryset` (the former bypasses the latter — kept as a latent trap before this PR).
- `MaintainerProfileForm` now converts storage → authoring on load, so existing `[[type:id:N]]` tokens render correctly in the bio textarea (fixes all slug-based link types in one pass).

## Test plan

- [ ] On `/profile/`, edit a bio containing `[[user:<someone>]]` and `[[machine:<slug>]]`. Both render as `<a>` tags on the rendered profile and as slug-format `[[type:slug]]` in the edit form.
- [ ] In any `[[` autocomplete, pick "User" — only directory-visible maintainers appear, sorted by recent activity.
- [ ] Demote a maintainer (remove from `Maintainers` group). On a page that links to them, the link renders as `*[broken link]*`; re-saving the source prunes the `RecordReference` row. Restoring the maintainer re-creates the row on the next save.
- [ ] `make test` (1823 tests pass locally including the 30+ new tests covering the contract end-to-end).