### PR TITLE
feat(maintenance): sort machine Problems view by status 

### DIFF
--- a/docs/Models.md
+++ b/docs/Models.md
@@ -98,7 +98,7 @@ PartRequest.objects.exclude(status="cancelled").filter(status__in=["requested", 
 The project uses this pattern in:
 
 - `MachineInstanceQuerySet` - `visible()`, `active_for_matching()`
-- `ProblemReportQuerySet` - `open()`, `search()`, `search_for_machine()`
+- `ProblemReportQuerySet` - `open()`, `search()`, `search_for_machine()`, `with_priority_sort()`, `with_status_sort()`, `for_wall_display()`, `for_open_by_location()`
 - `LogEntryQuerySet` - `search()`, `search_for_machine()`, `search_for_problem_report()`
 - `PartRequestQuerySet` - `active()`, `pending()`, `search()`, `search_for_machine()`
 - `PartRequestUpdateQuerySet` - `search()`, `search_for_machine()`, `search_for_part_request()`

--- a/docs/Views.md
+++ b/docs/Views.md
@@ -188,15 +188,17 @@ Pass `machine=` for a machine-scoped feed (uses `search_for_machine`) or omit it
 ```python
 from flipfix.apps.core.feed import get_feed_page, FEED_CONFIGS
 
-# Machine-scoped feed
+# Machine-scoped feed - pass the whole FeedConfig (not entry_types alone)
+# so the per-source DB ordering travels with the entry-type list.
 entries, has_next = get_feed_page(
     machine=self.machine,
-    entry_types=feed_config.entry_types,
+    feed_config=feed_config,
     page_num=page_num,
     search_query=search_query,
 )
 
-# Global feed (all machines)
+# Global feed (all machines) - feed_config defaults to None, which means
+# "all registered types, default -occurred_at ordering".
 entries, has_next = get_feed_page(
     page_num=page_num,
     search_query=search_query,
@@ -204,6 +206,16 @@ entries, has_next = get_feed_page(
 ```
 
 Use `PageCursor` when templates expect `page_obj` interface but Django's `Paginator` can't be used (multiple querysets).
+
+### `FeedConfig.source_order_by` invariant
+
+Each `FeedConfig` declares a `source_order_by` tuple that controls the DB ordering applied to its participating sources. It defaults to `("-occurred_at",)`, which matches the in-memory merge-sort comparator in `get_feed_page`.
+
+**Invariant:** if more than one source participates (`len(entry_types) != 1` — and that includes `entry_types=()`, the "all registered types" sentinel), `source_order_by` must remain `("-occurred_at",)`. `FeedConfig.__post_init__` enforces this at construction time and raises `ValueError` otherwise.
+
+Why: pagination fetches an `offset + page_size + 1` slab from each source using `source_order_by`, then merges by `occurred_at` descending. If the per-source key disagrees with the merge key, the slab is the wrong window — a row that should be on the requested page can fall outside the per-source slab and silently vanish from the result.
+
+Single-source tabs (e.g. Problems, which uses `("status_sort", "priority_sort", "-occurred_at")`) are exempt because `get_feed_page` skips the merge entirely when only one source participates and trusts the DB ordering.
 
 ## Query Optimization
 

--- a/flipfix/apps/catalog/tests/test_machine_feed.py
+++ b/flipfix/apps/catalog/tests/test_machine_feed.py
@@ -7,8 +7,11 @@ This view handles four URL patterns via query params:
 - /machines/slug/?f=parts → parts requests and updates only
 """
 
+from datetime import timedelta
+
 from django.test import RequestFactory, TestCase, tag
 from django.urls import reverse
+from django.utils import timezone
 
 from flipfix.apps.accounts.models import Maintainer
 from flipfix.apps.catalog.views_inline import MachineInlineUpdateView
@@ -19,10 +22,11 @@ from flipfix.apps.core.test_utils import (
     create_machine,
     create_machine_model,
     create_maintainer_user,
+    create_part_request,
     create_problem_report,
     create_user,
 )
-from flipfix.apps.maintenance.models import LogEntryMedia
+from flipfix.apps.maintenance.models import LogEntryMedia, ProblemReport
 from flipfix.apps.parts.models import PartRequest, PartRequestUpdate
 
 
@@ -437,3 +441,168 @@ class RenderLatestLogEntryQueryTests(TestDataMixin, TestCase):
             html = self.view._render_latest_log_entry(self.machine, self.request)
 
         self.assertEqual(html, "")
+
+
+@tag("views")
+class MachineFeedOrderingTests(TestDataMixin, TestCase):
+    """Tests for per-tab sort order on the machine activity feed.
+
+    The Problems tab uses ``(status_sort, priority_sort, -occurred_at)`` so
+    actionable items rise to the top.  Every other tab is purely chronological.
+    Asserting against ``response.context["entries"]`` keeps these tests focused
+    on feed ordering rather than template structure.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.feed_url = reverse("maintainer-machine-detail", kwargs={"slug": self.machine.slug})
+        self.client.force_login(self.maintainer_user)
+        self.now = timezone.now()
+
+    def test_problems_tab_orders_status_then_priority_then_recency(self):
+        """Open beats closed, then full priority enum order, then newest-first.
+
+        Covers all five ``Priority`` values so any pairwise inversion in the
+        enum's defined order is caught.  Created in a deliberately scrambled
+        order so creation-order coincidence can't pass the test.
+        """
+        closed_unplayable = create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.CLOSED,
+            priority=ProblemReport.Priority.UNPLAYABLE,
+            description="Closed unplayable from yesterday",
+            occurred_at=self.now - timedelta(days=1),
+        )
+        open_minor = create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.MINOR,
+            description="Open minor from an hour ago",
+            occurred_at=self.now - timedelta(hours=1),
+        )
+        open_unplayable = create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.UNPLAYABLE,
+            description="Open unplayable from last week",
+            occurred_at=self.now - timedelta(days=7),
+        )
+        open_untriaged = create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.UNTRIAGED,
+            description="Open untriaged from two weeks ago",
+            occurred_at=self.now - timedelta(days=14),
+        )
+        open_major = create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.MAJOR,
+            description="Open major from three days ago",
+            occurred_at=self.now - timedelta(days=3),
+        )
+        open_task = create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.TASK,
+            description="Open task from two days ago",
+            occurred_at=self.now - timedelta(days=2),
+        )
+
+        response = self.client.get(self.feed_url, {"f": "problems"})
+
+        entries = list(response.context["entries"])
+        self.assertEqual(
+            [e.pk for e in entries],
+            [
+                open_untriaged.pk,
+                open_unplayable.pk,
+                open_major.pk,
+                open_minor.pk,
+                open_task.pk,
+                closed_unplayable.pk,
+            ],
+        )
+
+    def test_all_tab_orders_strictly_by_occurred_at(self):
+        """All Activity tab is chronological across heterogeneous entry types."""
+        old_log = create_log_entry(
+            machine=self.machine,
+            text="Old log",
+            occurred_at=self.now - timedelta(days=3),
+        )
+        newer_problem = create_problem_report(
+            machine=self.machine,
+            description="Newer problem",
+            occurred_at=self.now - timedelta(days=1),
+        )
+        newest_part = create_part_request(
+            machine=self.machine,
+            text="Newest part",
+            occurred_at=self.now - timedelta(hours=1),
+        )
+
+        response = self.client.get(self.feed_url)
+
+        entries = list(response.context["entries"])
+        # Identify entries by (type, pk) because pks collide across entry-type
+        # tables (e.g. LogEntry and ProblemReport both start at 1).
+        ids = [(type(e).__name__, e.pk) for e in entries]
+        self.assertEqual(
+            ids,
+            [
+                (type(newest_part).__name__, newest_part.pk),
+                (type(newer_problem).__name__, newer_problem.pk),
+                (type(old_log).__name__, old_log.pk),
+            ],
+        )
+
+    def test_logs_tab_orders_by_occurred_at_descending(self):
+        """Single-source Logs tab stays chronological."""
+        oldest = create_log_entry(
+            machine=self.machine,
+            text="oldest log",
+            occurred_at=self.now - timedelta(days=2),
+        )
+        middle = create_log_entry(
+            machine=self.machine,
+            text="middle log",
+            occurred_at=self.now - timedelta(days=1),
+        )
+        newest = create_log_entry(
+            machine=self.machine,
+            text="newest log",
+            occurred_at=self.now,
+        )
+
+        response = self.client.get(self.feed_url, {"f": "logs"})
+
+        self.assertEqual(
+            [e.pk for e in response.context["entries"]],
+            [newest.pk, middle.pk, oldest.pk],
+        )
+
+    def test_parts_tab_orders_by_occurred_at_descending(self):
+        """Single-source Parts tab stays chronological."""
+        oldest = create_part_request(
+            machine=self.machine,
+            text="oldest request",
+            occurred_at=self.now - timedelta(days=2),
+        )
+        middle = create_part_request(
+            machine=self.machine,
+            text="middle request",
+            occurred_at=self.now - timedelta(days=1),
+        )
+        newest = create_part_request(
+            machine=self.machine,
+            text="newest request",
+            occurred_at=self.now,
+        )
+
+        response = self.client.get(self.feed_url, {"f": "parts"})
+
+        self.assertEqual(
+            [e.pk for e in response.context["entries"]],
+            [newest.pk, middle.pk, oldest.pk],
+        )

--- a/flipfix/apps/catalog/views/machines.py
+++ b/flipfix/apps/catalog/views/machines.py
@@ -207,7 +207,7 @@ class MachineFeedView(TemplateView):
         # Get first page of entries
         entries, has_next = get_feed_page(
             machine=self.machine,
-            entry_types=feed_config.entry_types,
+            feed_config=feed_config,
             page_num=1,
             search_query=search_query or None,
         )
@@ -258,7 +258,7 @@ class MachineFeedPartialView(View):
 
         page_items, has_next = get_feed_page(
             machine=machine,
-            entry_types=feed_config.entry_types,
+            feed_config=feed_config,
             page_num=page_num,
             search_query=search_query,
         )

--- a/flipfix/apps/core/feed.py
+++ b/flipfix/apps/core/feed.py
@@ -25,15 +25,51 @@ if TYPE_CHECKING:
     from flipfix.apps.catalog.models import MachineInstance
 
 
+_DEFAULT_FEED_ORDER: tuple[str, ...] = ("-occurred_at",)
+
+
 @dataclass(frozen=True)
 class FeedConfig:
-    """Configuration for a machine feed filter tab."""
+    """Configuration for a machine feed filter tab.
+
+    ``source_order_by`` controls the DB ordering applied to each participating
+    source queryset.  It defaults to ``("-occurred_at",)``, which matches the
+    Python merge-sort comparator in :func:`get_feed_page`.
+
+    **Invariant:** if more than one source participates (``len(entry_types) != 1``,
+    which includes ``entry_types=()`` \u2014 the "all registered types" sentinel), the
+    sort key must remain ``("-occurred_at",)``.  Pagination fetches a per-source
+    slab using ``source_order_by`` and then merges by ``occurred_at`` desc \u2014 if
+    the per-source key disagrees with the merge key, the slab is the wrong
+    window and entries silently vanish from the result.  Enforced by
+    :meth:`__post_init__`.
+    """
 
     title_suffix: str  # Appended to browser title, e.g. "- Logs"
     breadcrumb_label: str | None  # Final breadcrumb text, None for activity feed
     entry_types: tuple[str, ...]  # Which entry types to include; () means all registered
     empty_message: str  # Shown when feed has no entries
     search_empty_message: str  # Shown when search has no results
+    source_order_by: tuple[str, ...] = _DEFAULT_FEED_ORDER
+
+    def __post_init__(self) -> None:
+        if not self.source_order_by:
+            # An empty order tuple would expand to ``QuerySet.order_by()``,
+            # which clears all ordering in Django 5.2 and returns rows in
+            # unspecified DB order — silently destabilising pagination.
+            raise ValueError(
+                "FeedConfig.source_order_by cannot be empty; provide at "
+                "least one field (e.g. '-occurred_at')."
+            )
+        if len(self.entry_types) != 1 and self.source_order_by != _DEFAULT_FEED_ORDER:
+            raise ValueError(
+                "FeedConfig.source_order_by must be ('-occurred_at',) when "
+                "entry_types has zero or multiple entries; otherwise the "
+                "per-source slab will not align with the merge comparator "
+                "and entries can silently drop from paginated results. "
+                f"Got entry_types={self.entry_types!r}, "
+                f"source_order_by={self.source_order_by!r}."
+            )
 
 
 FEED_CONFIGS: dict[str, FeedConfig] = {
@@ -57,6 +93,11 @@ FEED_CONFIGS: dict[str, FeedConfig] = {
         entry_types=("problem_report",),
         empty_message="No problem reports yet.",
         search_empty_message="No problem reports match your search.",
+        # `status_sort` and `priority_sort` are CASE annotations applied in
+        # MaintenanceConfig._register_feed_sources (maintenance/apps.py).
+        # The two declarations must stay in sync \u2014 dropping either side
+        # raises FieldError when the Problems tab is rendered.
+        source_order_by=("status_sort", "priority_sort", "-occurred_at"),
     ),
     "parts": FeedConfig(
         title_suffix=" \u00b7 Part Requests",
@@ -141,12 +182,23 @@ def clear_feed_source_registry() -> None:
     _feed_source_registry.clear()
 
 
+def _resolve_entry_types(feed_config: FeedConfig | None) -> tuple[str, ...]:
+    """Resolve the entry-type tuple for a feed query.
+
+    ``None`` and an empty ``entry_types`` both mean "all registered types" —
+    the convention used by the global activity feed and the All Activity tab.
+    """
+    if feed_config is None or not feed_config.entry_types:
+        return get_all_entry_types()
+    return feed_config.entry_types
+
+
 def get_feed_page(
     page_num: int = 1,
     page_size: int = settings.LIST_PAGE_SIZE,
     search_query: str | None = None,
     machine: MachineInstance | None = None,
-    entry_types: tuple[str, ...] = (),
+    feed_config: FeedConfig | None = None,
 ) -> tuple[list[Any], bool]:
     """Get a paginated page of activity entries.
 
@@ -155,15 +207,28 @@ def get_feed_page(
     When machine is None, returns entries across all machines with global
     search (includes machine name matching).
 
-    An empty ``entry_types`` tuple means "all registered types".
+    ``feed_config=None`` means "all registered types, default ``-occurred_at``
+    ordering" — the zero-config behavior used by global activity feeds.
+    Otherwise the config supplies both ``entry_types`` and ``source_order_by``;
+    its :meth:`FeedConfig.__post_init__` guarantees the per-source key is
+    compatible with the merge-sort comparator below.
 
-    Uses merge-sort style pagination: fetches just enough from each table
-    to construct the requested page.
+    For multi-source feeds, uses merge-sort style pagination: fetches just
+    enough from each table to construct the requested page.  For single-source
+    feeds, skips the Python merge entirely and trusts the DB ordering — this
+    is required for correctness, not an optimization, because single-source
+    tabs may use a key (e.g. ``status_sort, priority_sort, -occurred_at``)
+    that differs from the merge comparator.
 
     Returns (page_items, has_next) tuple.
     """
-    if not entry_types:
-        entry_types = get_all_entry_types()
+    # Both branches arrive safe against the merge-comparator invariant:
+    #   - None: implicit default order matches the merge key.
+    #   - FeedConfig: __post_init__ guarantees multi-source configs use the
+    #     default order; single-source configs may use any key and bypass the
+    #     merge below.
+    entry_types = _resolve_entry_types(feed_config)
+    order_by = feed_config.source_order_by if feed_config else _DEFAULT_FEED_ORDER
 
     offset = (page_num - 1) * page_size
     # Fetch one extra to detect if more pages exist (countless pagination pattern)
@@ -174,14 +239,20 @@ def get_feed_page(
     for entry_type in entry_types:
         source = _feed_source_registry.get(entry_type)
         if source:
-            all_entries.extend(_fetch_entries(source, machine, search_query, fetch_limit))
+            all_entries.extend(_fetch_entries(source, machine, search_query, fetch_limit, order_by))
 
-    # Sort by occurred_at descending (all entry types share this field)
-    combined = sorted(
-        all_entries,
-        key=lambda x: x.occurred_at,
-        reverse=True,
-    )
+    if len(entry_types) == 1:
+        # Single source: DB ordering is already correct; re-sorting by
+        # occurred_at would destroy any status/priority bucketing.
+        combined = all_entries
+    else:
+        # Merge sort by occurred_at descending (all entry types share this
+        # field, and the invariant guarantees per-source order matches).
+        combined = sorted(
+            all_entries,
+            key=lambda x: x.occurred_at,
+            reverse=True,
+        )
 
     # Slice to requested page
     page_items = combined[offset : offset + page_size]
@@ -195,6 +266,7 @@ def _fetch_entries(
     machine: MachineInstance | None,
     search_query: str | None,
     limit: int,
+    order_by: tuple[str, ...],
 ) -> list[Any]:
     """Fetch entries for a single source, scoped to machine or global."""
     queryset = source.get_base_queryset()
@@ -208,7 +280,7 @@ def _fetch_entries(
         if search_query:
             queryset = queryset.search(search_query)  # type: ignore[attr-defined]
 
-    queryset = queryset.order_by("-occurred_at")
+    queryset = queryset.order_by(*order_by)
     entries = list(queryset[:limit])
 
     # Tag entries with metadata from their source for template rendering

--- a/flipfix/apps/core/tests/test_feed_source_registry.py
+++ b/flipfix/apps/core/tests/test_feed_source_registry.py
@@ -4,6 +4,7 @@ from django.db.models import QuerySet
 from django.test import TestCase, tag
 
 from flipfix.apps.core.feed import (
+    FeedConfig,
     FeedEntrySource,
     _feed_source_registry,
     clear_feed_source_registry,
@@ -105,3 +106,70 @@ class RegisterFeedSourceTests(TestCase):
         """clear_feed_source_registry() removes all entries."""
         clear_feed_source_registry()
         self.assertEqual(len(_feed_source_registry), 0)
+
+
+@tag("models")
+class FeedConfigInvariantTests(TestCase):
+    """Tests for the ``FeedConfig.__post_init__`` source_order_by invariant.
+
+    Multi-source feeds must use the default ``("-occurred_at",)`` order so the
+    per-source DB slab aligns with the in-memory merge comparator.  See the
+    dataclass docstring for the failure mode this guard prevents.
+    """
+
+    _valid_kwargs = {
+        "title_suffix": "",
+        "breadcrumb_label": None,
+        "empty_message": "",
+        "search_empty_message": "",
+    }
+
+    def test_single_source_can_use_custom_order(self):
+        """Single-source configs may override source_order_by freely."""
+        config = FeedConfig(
+            entry_types=("problem_report",),
+            source_order_by=("status_sort", "priority_sort", "-occurred_at"),
+            **self._valid_kwargs,
+        )
+        self.assertEqual(
+            config.source_order_by,
+            ("status_sort", "priority_sort", "-occurred_at"),
+        )
+
+    def test_multi_source_with_custom_order_raises(self):
+        """Multi-source config with non-default order is rejected at construction."""
+        with self.assertRaises(ValueError) as ctx:
+            FeedConfig(
+                entry_types=("log", "problem_report"),
+                source_order_by=("status_sort",),
+                **self._valid_kwargs,
+            )
+        self.assertIn("source_order_by", str(ctx.exception))
+
+    def test_empty_entry_types_with_custom_order_raises(self):
+        """The () sentinel (all registered types) counts as multi-source."""
+        with self.assertRaises(ValueError):
+            FeedConfig(
+                entry_types=(),
+                source_order_by=("status_sort",),
+                **self._valid_kwargs,
+            )
+
+    def test_default_order_allowed_for_any_arity(self):
+        """The default order is always valid, regardless of entry_types count."""
+        # Single
+        FeedConfig(entry_types=("log",), **self._valid_kwargs)
+        # Multi
+        FeedConfig(entry_types=("log", "problem_report"), **self._valid_kwargs)
+        # All
+        FeedConfig(entry_types=(), **self._valid_kwargs)
+
+    def test_empty_source_order_by_raises(self):
+        """Empty source_order_by is rejected — it would clear DB ordering."""
+        with self.assertRaises(ValueError) as ctx:
+            FeedConfig(
+                entry_types=("log",),
+                source_order_by=(),
+                **self._valid_kwargs,
+            )
+        self.assertIn("cannot be empty", str(ctx.exception))

--- a/flipfix/apps/core/tests/test_global_activity_feed.py
+++ b/flipfix/apps/core/tests/test_global_activity_feed.py
@@ -4,15 +4,20 @@ The global feed shows all activity across all machines and is the home page
 for maintainers.
 """
 
+from datetime import timedelta
+
 from django.test import TestCase, tag
 from django.urls import reverse
+from django.utils import timezone
 
+from flipfix.apps.core.feed import get_feed_page
 from flipfix.apps.core.test_utils import (
     TestDataMixin,
     create_log_entry,
     create_machine,
     create_machine_model,
     create_maintainer_user,
+    create_part_request,
     create_problem_report,
     create_user,
 )
@@ -224,3 +229,47 @@ class GlobalFeedPartialViewTests(TestDataMixin, TestCase):
         data = response.json()
         # Page 2 with default page size should work
         self.assertIsInstance(data["items"], str)
+
+
+@tag("views")
+class GlobalFeedOrderingTests(TestDataMixin, TestCase):
+    """Tests for the multi-source merge order of the global activity feed."""
+
+    def test_merge_sorts_strictly_by_occurred_at_descending(self):
+        """Entries from heterogeneous sources interleave by ``occurred_at``.
+
+        Exercises ``get_feed_page`` directly (rather than the view) so the
+        assertion is decoupled from template rendering and uses the same code
+        path the AJAX partial uses.
+        """
+        now = timezone.now()
+        old_log = create_log_entry(
+            machine=self.machine,
+            text="old log",
+            occurred_at=now - timedelta(days=3),
+        )
+        newer_problem = create_problem_report(
+            machine=self.machine,
+            description="newer problem",
+            occurred_at=now - timedelta(days=1),
+        )
+        newest_part = create_part_request(
+            machine=self.machine,
+            text="newest part",
+            occurred_at=now - timedelta(hours=1),
+        )
+
+        entries, _ = get_feed_page(page_num=1)
+
+        # Identify entries by (type, pk) because pks collide across entry-type
+        # tables (e.g. LogEntry and ProblemReport both start at 1).
+        ordered_ids = [(type(e).__name__, e.pk) for e in entries]
+        # Expect strict newest-first order regardless of entry type.
+        self.assertEqual(
+            ordered_ids[:3],
+            [
+                (type(newest_part).__name__, newest_part.pk),
+                (type(newer_problem).__name__, newer_problem.pk),
+                (type(old_log).__name__, old_log.pk),
+            ],
+        )

--- a/flipfix/apps/maintenance/apps.py
+++ b/flipfix/apps/maintenance/apps.py
@@ -48,8 +48,14 @@ class MaintenanceConfig(AppConfig):
                 queryset=LogEntry.objects.order_by("-occurred_at"),
                 to_attr="prefetched_log_entries",
             )
-            return ProblemReport.objects.select_related("reported_by_user").prefetch_related(
-                latest_log_prefetch, "media"
+            # status_sort + priority_sort annotations are referenced by
+            # FEED_CONFIGS["problems"].source_order_by in core/feed.py.
+            # The two declarations must stay in sync.
+            return (
+                ProblemReport.objects.select_related("reported_by_user")
+                .prefetch_related(latest_log_prefetch, "media")
+                .with_status_sort()
+                .with_priority_sort()
             )
 
         register_feed_source(

--- a/flipfix/apps/maintenance/models.py
+++ b/flipfix/apps/maintenance/models.py
@@ -72,6 +72,35 @@ class ProblemReportQuerySet(SearchableQuerySetMixin, models.QuerySet):
             for i, (value, _) in enumerate(ProblemReport.Priority.choices)
         ]
 
+    def with_priority_sort(self):
+        """Annotate ``priority_sort`` for ordering by ``Priority`` enum position.
+
+        Cheap constant-time ``CASE`` expression — no joins.  Order by the
+        annotation ascending to get the enum's defined order (untriaged first,
+        task last).
+        """
+        return self.annotate(
+            priority_sort=Case(
+                *self._priority_whens(),
+                default=Value(999),
+                output_field=IntegerField(),
+            )
+        )
+
+    def with_status_sort(self):
+        """Annotate ``status_sort`` so open reports sort before closed.
+
+        Cheap constant-time ``CASE`` expression — no joins.  Order by the
+        annotation ascending to get open (0) before closed (1).
+        """
+        return self.annotate(
+            status_sort=Case(
+                When(status=ProblemReport.Status.OPEN, then=Value(0)),
+                default=Value(1),
+                output_field=IntegerField(),
+            )
+        )
+
     def for_wall_display(self, location_slugs: list[str]):
         """Build the queryset for the wall display board.
 
@@ -79,18 +108,14 @@ class ProblemReportQuerySet(SearchableQuerySetMixin, models.QuerySet):
         priority then newest first.  Annotates ``media_count`` for compact
         display (no prefetch of full media objects).
         """
-        priority_sort = Case(
-            *self._priority_whens(),
-            default=Value(999),
-            output_field=IntegerField(),
-        )
         return (
             self.filter(
                 status=ProblemReport.Status.OPEN,
                 machine__location__slug__in=location_slugs,
             )
             .select_related("machine", "machine__model", "machine__location")
-            .annotate(media_count=Count("media"), priority_sort=priority_sort)
+            .annotate(media_count=Count("media"))
+            .with_priority_sort()
             .order_by("priority_sort", "-occurred_at")
         )
 
@@ -106,16 +131,11 @@ class ProblemReportQuerySet(SearchableQuerySetMixin, models.QuerySet):
             queryset=LogEntry.objects.order_by("-occurred_at"),
             to_attr="prefetched_log_entries",
         )
-        priority_sort = Case(
-            *self._priority_whens(),
-            default=Value(999),
-            output_field=IntegerField(),
-        )
         return (
             self.filter(status=ProblemReport.Status.OPEN)
             .select_related("machine", "machine__model", "machine__location")
             .prefetch_related(latest_log_prefetch, "media")
-            .annotate(priority_sort=priority_sort)
+            .with_priority_sort()
             .order_by("priority_sort", "-occurred_at")
         )
 


### PR DESCRIPTION
## Summary

Each machine-feed tab now declares its own DB sort order via a new `FeedConfig.source_order_by` field; the Problems tab uses `(status_sort, priority_sort, -occurred_at)` so open beats closed, then enum-defined priority, then recency.

- A `FeedConfig.__post_init__` invariant prevents multi-source tabs from using a non-default key — otherwise the per-source DB slab would misalign with the in-memory merge comparator and silently drop entries.
- `get_feed_page` now takes `feed_config=` instead of `entry_types=` so the entry-type list and the sort key travel together.
- Single-source tabs skip the Python merge entirely; this is required for correctness, not optimization, because their key may differ from the merge comparator.
- Extracts duplicated `Case(...)` priority annotations into `with_priority_sort()` / `with_status_sort()` queryset helpers on `ProblemReportQuerySet`.

## Test plan

- [ ] `make test` and `make quality` pass.
- [ ] Visit `/machines/<slug>/?f=problems` on a machine with both open and closed reports — confirm open above closed and that priority orders correctly within each bucket (untriaged → unplayable → major → minor → task).
- [ ] Spot-check the All Activity, Logs, and Parts tabs to confirm they still order chronologically.
- [ ] Visit `/wall` and the global problem-report list (`/problems/`) to confirm the priority-ordered queries (refactored to use `with_priority_sort()`) still produce identical output.
- [ ] Confirm the global activity feed home page remains in `-occurred_at` order across heterogeneous entry types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced feed configuration documentation with guidance on global and machine-scoped feed behavior and multi-source ordering requirements

* **Tests**
  * Added comprehensive test coverage validating entry ordering across all feed tabs and multi-source activity feeds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipfix/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->