### PR TITLE
feat(maintenance): add Now Playing mode to wall display

### DIFF
--- a/flipfix/apps/catalog/templatetags/catalog_tags.py
+++ b/flipfix/apps/catalog/templatetags/catalog_tags.py
@@ -75,6 +75,27 @@ def manufacturer_year(model):
     return " \u00b7 ".join(parts)
 
 
+@register.filter
+def manufacturer_year_parens(model):
+    """Return '(Manufacturer, Year)' for a machine model, or '' if both blank.
+
+    Comma-separated variant used by the Now Playing wall display.
+    Returns an empty string when both fields are blank, so templates
+    can omit the trailing label cleanly.
+
+    Usage:
+        {{ machine.model|manufacturer_year_parens }}
+    """
+    parts = []
+    if model.manufacturer:
+        parts.append(model.manufacturer)
+    if model.year:
+        parts.append(str(model.year))
+    if not parts:
+        return ""
+    return f"({', '.join(parts)})"
+
+
 # ---- Settable pills ---------------------------------------------------------
 
 

--- a/flipfix/apps/maintenance/tests/test_wall_display.py
+++ b/flipfix/apps/maintenance/tests/test_wall_display.py
@@ -550,10 +550,12 @@ class WallDisplayBoardNowPlayingTests(SuppressRequestLogsMixin, TestDataMixin, T
             },
         )
         content = response.content.decode()
-        # Floor wrapper has flex-grow: 1
-        self.assertIn('style="flex-grow: 1"', content)
-        # Workshop wrapper has flex-grow: 3
-        self.assertIn('style="flex-grow: 3"', content)
+        # Floor wrapper (first location) gets flex-grow: 1
+        self.assertIn(":nth-of-type(1)", content)
+        self.assertIn("flex-grow: 1;", content)
+        # Workshop wrapper (second location) gets flex-grow: 3
+        self.assertIn(":nth-of-type(2)", content)
+        self.assertIn("flex-grow: 3;", content)
 
     def test_now_playing_empty_location_still_gets_one_sub_column(self):
         """Locations with no working machines still claim a minimum flex slice."""
@@ -570,5 +572,5 @@ class WallDisplayBoardNowPlayingTests(SuppressRequestLogsMixin, TestDataMixin, T
         )
         content = response.content.decode()
         # Two flex-grow declarations: floor=2 (ceil(15/10)), workshop=1 (min)
-        self.assertIn('style="flex-grow: 2"', content)
-        self.assertIn('style="flex-grow: 1"', content)
+        self.assertIn("flex-grow: 2;", content)
+        self.assertIn("flex-grow: 1;", content)

--- a/flipfix/apps/maintenance/tests/test_wall_display.py
+++ b/flipfix/apps/maintenance/tests/test_wall_display.py
@@ -4,7 +4,7 @@ from constance.test import override_config
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from flipfix.apps.catalog.models import Location
+from flipfix.apps.catalog.models import Location, MachineInstance
 from flipfix.apps.core.test_utils import (
     SuppressRequestLogsMixin,
     TestDataMixin,
@@ -54,6 +54,26 @@ class WallDisplaySetupViewTests(SuppressRequestLogsMixin, TestDataMixin, TestCas
         response = self.client.get(self.url)
         self.assertContains(response, floor.name)
         self.assertContains(response, workshop.name)
+
+    def test_mode_dropdown_renders_both_options(self):
+        """The setup page exposes both display modes in a dropdown."""
+        self.client.force_login(self.maintainer_user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'name="mode"')
+        self.assertContains(response, 'value="workshop"')
+        self.assertContains(response, 'value="now-playing"')
+
+    def test_mode_selection_preserved_in_dropdown(self):
+        """The dropdown re-renders with the requested mode pre-selected."""
+        self.client.force_login(self.maintainer_user)
+        response = self.client.get(self.url, {"mode": "now-playing"})
+        self.assertContains(response, 'value="now-playing" selected')
+
+    def test_workshop_is_default_mode(self):
+        """When no mode is given, the workshop option is selected."""
+        self.client.force_login(self.maintainer_user)
+        response = self.client.get(self.url)
+        self.assertContains(response, 'value="workshop" selected')
 
 
 @tag("views")
@@ -366,3 +386,189 @@ class WallDisplayQuerySetTests(TestDataMixin, TestCase):
         ProblemReportMedia.objects.create(problem_report=report, file="b.jpg")
         qs = ProblemReport.objects.for_wall_display(["floor"])
         self.assertEqual(qs.first().media_count, 2)
+
+
+@tag("views")
+class WallDisplayBoardNowPlayingTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
+    """Tests for the now-playing mode of the wall display board."""
+
+    def setUp(self):
+        super().setUp()
+        self.floor, _ = Location.objects.get_or_create(
+            slug="floor", defaults={"name": "Floor", "sort_order": 1}
+        )
+        self.workshop, _ = Location.objects.get_or_create(
+            slug="workshop", defaults={"name": "Workshop", "sort_order": 2}
+        )
+        self.board_url = reverse("wall-display-board")
+        self.client.force_login(self.maintainer_user)
+
+    def _make_model(self, name, manufacturer="Williams", year=1994):
+        from flipfix.apps.catalog.models import MachineModel
+
+        return MachineModel.objects.create(name=name, manufacturer=manufacturer, year=year)
+
+    def test_unknown_mode_falls_back_to_workshop(self):
+        """An unknown mode value renders the workshop board, not an error."""
+        create_machine(slug="m1", location=self.floor, name="Visible Machine")
+        create_problem_report(
+            machine=create_machine(slug="m2", location=self.floor),
+            description="Workshop problem",
+        )
+        response = self.client.get(self.board_url, {"mode": "bogus", "location": ["floor"]})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Workshop problem")
+
+    def test_now_playing_shows_only_working_machines(self):
+        """Only machines with operational_status=GOOD appear in now-playing."""
+        good = create_machine(
+            slug="good-machine",
+            name="Good Machine",
+            location=self.floor,
+            operational_status=MachineInstance.OperationalStatus.GOOD,
+        )
+        for status, slug, label in [
+            (MachineInstance.OperationalStatus.BROKEN, "broken-m", "Broken Machine"),
+            (MachineInstance.OperationalStatus.FIXING, "fixing-m", "Fixing Machine"),
+            (MachineInstance.OperationalStatus.UNKNOWN, "unknown-m", "Unknown Machine"),
+        ]:
+            create_machine(slug=slug, name=label, location=self.floor, operational_status=status)
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, good.name)
+        self.assertNotContains(response, "Broken Machine")
+        self.assertNotContains(response, "Fixing Machine")
+        self.assertNotContains(response, "Unknown Machine")
+
+    def test_now_playing_filters_by_location(self):
+        """Now-playing respects the location filter."""
+        create_machine(slug="floor-good", name="Floor Good", location=self.floor)
+        create_machine(slug="workshop-good", name="Workshop Good", location=self.workshop)
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "Floor Good")
+        self.assertNotContains(response, "Workshop Good")
+
+    def test_now_playing_sorts_oldest_year_first(self):
+        """Machines are ordered by manufacturing year ascending."""
+        old_model = self._make_model("Old Model", year=1980)
+        new_model = self._make_model("New Model", year=2020)
+        create_machine(slug="new-m", name="Newer Game", location=self.floor, model=new_model)
+        create_machine(slug="old-m", name="Older Game", location=self.floor, model=old_model)
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        content = response.content.decode()
+        self.assertLess(content.index("Older Game"), content.index("Newer Game"))
+
+    def test_now_playing_shows_manufacturer_and_year(self):
+        """Each row renders 'Name (Manufacturer, Year)'."""
+        model = self._make_model("Addams", manufacturer="Williams", year=1994)
+        create_machine(slug="taf", name="The Addams Family", location=self.floor, model=model)
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "The Addams Family")
+        self.assertContains(response, "(Williams, 1994)")
+
+    def test_now_playing_omits_parens_when_neither_present(self):
+        """No naked parens when both manufacturer and year are blank."""
+        from flipfix.apps.catalog.models import MachineModel
+
+        model = MachineModel.objects.create(name="Anon Model", manufacturer="", year=None)
+        create_machine(slug="anon", name="Mystery Machine", location=self.floor, model=model)
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "Mystery Machine")
+        self.assertNotContains(response, "()")
+
+    def test_now_playing_shows_empty_message_when_no_working_machines(self):
+        """An empty location column shows the now-playing empty message."""
+        create_machine(
+            slug="broken-only",
+            name="Broken Only",
+            location=self.floor,
+            operational_status=MachineInstance.OperationalStatus.BROKEN,
+        )
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "No machines playing.")
+        self.assertNotContains(response, "Broken Only")
+
+    def test_now_playing_page_title(self):
+        """The page title reflects the now-playing mode."""
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "Now Playing · Wall Display")
+
+    def test_now_playing_does_not_show_problem_reports(self):
+        """Now-playing renders no problem-report rows, even on working machines."""
+        good = create_machine(slug="good-machine", name="Good Machine", location=self.floor)
+        create_problem_report(machine=good, description="Stealth problem text")
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "Good Machine")
+        self.assertNotContains(response, "Stealth problem text")
+
+    def test_now_playing_per_column_sets_grid_template(self):
+        """The per_column param flows through as a CSS custom property."""
+        create_machine(slug="m1", location=self.floor)
+        response = self.client.get(
+            self.board_url,
+            {"mode": "now-playing", "location": ["floor"], "per_column": "5"},
+        )
+        self.assertContains(response, "grid-template-rows: repeat(5, auto)")
+
+    def test_now_playing_per_column_defaults_to_10(self):
+        """Without an explicit per_column, the template uses the default of 10."""
+        create_machine(slug="m1", location=self.floor)
+        response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
+        self.assertContains(response, "grid-template-rows: repeat(10, auto)")
+
+    def test_now_playing_per_column_invalid_falls_back_to_default(self):
+        """Non-numeric per_column values fall back to the default."""
+        create_machine(slug="m1", location=self.floor)
+        response = self.client.get(
+            self.board_url,
+            {"mode": "now-playing", "location": ["floor"], "per_column": "abc"},
+        )
+        self.assertContains(response, "grid-template-rows: repeat(10, auto)")
+
+    def test_now_playing_per_column_clamped_to_max(self):
+        """Per-column values above the cap are clamped down."""
+        create_machine(slug="m1", location=self.floor)
+        response = self.client.get(
+            self.board_url,
+            {"mode": "now-playing", "location": ["floor"], "per_column": "9999"},
+        )
+        self.assertContains(response, "grid-template-rows: repeat(50, auto)")
+
+    def test_now_playing_location_flex_matches_sub_column_count(self):
+        """Locations get flex-grow proportional to the number of sub-columns they need."""
+        # 5 machines on floor → 1 sub-column at per_column=10
+        for i in range(5):
+            create_machine(slug=f"floor-{i}", location=self.floor)
+        # 25 machines on workshop → 3 sub-columns at per_column=10 (ceil(25/10))
+        for i in range(25):
+            create_machine(slug=f"workshop-{i}", location=self.workshop)
+        response = self.client.get(
+            self.board_url,
+            {
+                "mode": "now-playing",
+                "location": ["floor", "workshop"],
+                "per_column": "10",
+            },
+        )
+        content = response.content.decode()
+        # Floor wrapper has flex-grow: 1
+        self.assertIn('style="flex-grow: 1"', content)
+        # Workshop wrapper has flex-grow: 3
+        self.assertIn('style="flex-grow: 3"', content)
+
+    def test_now_playing_empty_location_still_gets_one_sub_column(self):
+        """Locations with no working machines still claim a minimum flex slice."""
+        # Workshop has no machines; flex should still be at least 1.
+        for i in range(15):
+            create_machine(slug=f"floor-{i}", location=self.floor)
+        response = self.client.get(
+            self.board_url,
+            {
+                "mode": "now-playing",
+                "location": ["floor", "workshop"],
+                "per_column": "10",
+            },
+        )
+        content = response.content.decode()
+        # Two flex-grow declarations: floor=2 (ceil(15/10)), workshop=1 (min)
+        self.assertIn('style="flex-grow: 2"', content)
+        self.assertIn('style="flex-grow: 1"', content)

--- a/flipfix/apps/maintenance/views/wall_display.py
+++ b/flipfix/apps/maintenance/views/wall_display.py
@@ -2,13 +2,66 @@
 
 from __future__ import annotations
 
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+
+from django.db.models import F
 from django.views.generic import TemplateView
 
-from flipfix.apps.catalog.models import Location
-from flipfix.apps.core.columns import build_location_columns, group_by_machine
+from flipfix.apps.catalog.models import Location, MachineInstance
+from flipfix.apps.core.columns import Column, build_location_columns, group_by_machine
 from flipfix.apps.maintenance.models import ProblemReport
 
+
+@dataclass
+class NowPlayingColumn:
+    """A location's machines plus how many sub-columns it should occupy.
+
+    `sub_columns` lets the outer flex container size each location
+    proportionally to its content, so a location with 30 machines gets
+    more horizontal space than one with 5.
+    """
+
+    label: str
+    items: list[MachineInstance]
+    sub_columns: int
+
+
 MIN_REFRESH_SECONDS = 10
+DEFAULT_PER_COLUMN = 10
+MIN_PER_COLUMN = 1
+MAX_PER_COLUMN = 50
+
+
+class WallDisplayMode:
+    """The two display modes the wall board can render."""
+
+    WORKSHOP = "workshop"
+    NOW_PLAYING = "now-playing"
+    CHOICES = [(WORKSHOP, "Workshop"), (NOW_PLAYING, "Now Playing")]
+    DEFAULT = WORKSHOP
+    _VALID = {WORKSHOP, NOW_PLAYING}
+
+    @classmethod
+    def normalize(cls, value: str | None) -> str:
+        return value if value in cls._VALID else cls.DEFAULT
+
+
+_MODE_CARD_TEMPLATE = {
+    WallDisplayMode.WORKSHOP: "maintenance/partials/wall_display_entry.html",
+    WallDisplayMode.NOW_PLAYING: "maintenance/partials/wall_display_now_playing_entry.html",
+}
+
+_MODE_EMPTY_MESSAGE = {
+    WallDisplayMode.WORKSHOP: "No open problems 🥳",
+    WallDisplayMode.NOW_PLAYING: "No machines playing.",
+}
+
+_MODE_PAGE_TITLE = {
+    WallDisplayMode.WORKSHOP: "Problems",
+    WallDisplayMode.NOW_PLAYING: "Now Playing",
+}
 
 
 class WallDisplaySetupView(TemplateView):
@@ -19,6 +72,9 @@ class WallDisplaySetupView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["locations"] = Location.objects.all()
+        context["mode"] = WallDisplayMode.normalize(self.request.GET.get("mode"))
+        context["mode_choices"] = WallDisplayMode.CHOICES
+        context["default_per_column"] = DEFAULT_PER_COLUMN
         return context
 
 
@@ -29,6 +85,12 @@ class WallDisplayBoardView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        mode = WallDisplayMode.normalize(self.request.GET.get("mode"))
+        context["mode"] = mode
+        context["card_template"] = _MODE_CARD_TEMPLATE[mode]
+        context["empty_message"] = _MODE_EMPTY_MESSAGE[mode]
+        context["page_title"] = _MODE_PAGE_TITLE[mode]
+
         location_slugs = self.request.GET.getlist("location")
 
         if not location_slugs:
@@ -37,7 +99,6 @@ class WallDisplayBoardView(TemplateView):
             context["refresh_seconds"] = None
             return context
 
-        # Parse refresh parameter
         refresh_seconds = None
         raw_refresh = self.request.GET.get("refresh")
         if raw_refresh:
@@ -47,6 +108,8 @@ class WallDisplayBoardView(TemplateView):
                     refresh_seconds = value
             except (ValueError, TypeError):
                 pass
+
+        context["per_column"] = _parse_per_column(self.request.GET.get("per_column"))
 
         locations_by_slug = {
             loc.slug: loc for loc in Location.objects.filter(slug__in=location_slugs)
@@ -63,13 +126,55 @@ class WallDisplayBoardView(TemplateView):
         # Preserve URL param order so the setup page's drag order controls columns.
         locations = [locations_by_slug[s] for s in location_slugs]
 
-        reports = ProblemReport.objects.for_wall_display(location_slugs)
-        # No column-level cap: each MachineGroup handles its own overflow
-        # via MAX_VISIBLE_REPORTS + overflow_summary.
-        columns = build_location_columns(reports, locations)
-        # Replace flat report lists with MachineGroup objects
-        for column in columns:
-            column.items = group_by_machine(column.items)
+        if mode == WallDisplayMode.NOW_PLAYING:
+            columns = _build_now_playing_columns(location_slugs, locations, context["per_column"])
+        else:
+            columns = _build_workshop_columns(location_slugs, locations)
+
         context["columns"] = columns
         context["refresh_seconds"] = refresh_seconds
         return context
+
+
+def _parse_per_column(raw: str | None) -> int:
+    if not raw:
+        return DEFAULT_PER_COLUMN
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        return DEFAULT_PER_COLUMN
+    return max(MIN_PER_COLUMN, min(MAX_PER_COLUMN, value))
+
+
+def _build_workshop_columns(location_slugs: list[str], locations: list[Location]) -> list[Column]:
+    reports = ProblemReport.objects.for_wall_display(location_slugs)
+    # No column-level cap: each MachineGroup handles its own overflow
+    # via MAX_VISIBLE_REPORTS + overflow_summary.
+    columns = build_location_columns(reports, locations)
+    # Replace flat report lists with MachineGroup objects
+    for column in columns:
+        column.items = group_by_machine(column.items)
+    return columns
+
+
+def _build_now_playing_columns(
+    location_slugs: list[str], locations: list[Location], per_column: int
+) -> list[NowPlayingColumn]:
+    machines = (
+        MachineInstance.objects.filter(
+            operational_status=MachineInstance.OperationalStatus.GOOD,
+            location__slug__in=location_slugs,
+        )
+        .select_related("model", "location")
+        .order_by(F("model__year").asc(nulls_last=True), "name")
+    )
+    by_location: dict[int, list[MachineInstance]] = defaultdict(list)
+    for machine in machines:
+        by_location[machine.location_id].append(machine)
+    result = []
+    for location in locations:
+        items = by_location.get(location.pk, [])
+        # At least 1 so empty locations still claim a slice of horizontal space.
+        sub_columns = max(1, math.ceil(len(items) / per_column))
+        result.append(NowPlayingColumn(label=location.name, items=items, sub_columns=sub_columns))
+    return result

--- a/flipfix/static/core/styles.css
+++ b/flipfix/static/core/styles.css
@@ -559,6 +559,37 @@ body {
   color: var(--color-text-primary);
 }
 
+/* Now Playing: dense list of machines, sub-columns flow within each location */
+.now-playing-location {
+  min-width: 0;
+}
+
+.now-playing-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  column-gap: var(--space-4);
+  row-gap: 0;
+}
+
+.now-playing-row {
+  padding: 0 var(--space-2);
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.now-playing-row__model {
+  margin-left: var(--space-1);
+  color: var(--color-text-muted);
+  font-weight: var(--font-normal);
+}
+
+.now-playing-row__model:empty {
+  margin-left: 0;
+}
+
 .card__header {
   display: flex;
   justify-content: space-between;

--- a/templates/maintenance/partials/wall_display_now_playing_entry.html
+++ b/templates/maintenance/partials/wall_display_now_playing_entry.html
@@ -1,0 +1,5 @@
+{% load catalog_tags %}
+<div class="now-playing-row">
+  <strong>{{ entry.short_display_name }}</strong>
+  <span class="now-playing-row__model">{{ entry.model|manufacturer_year_parens }}</span>
+</div>

--- a/templates/maintenance/wall_display_board.html
+++ b/templates/maintenance/wall_display_board.html
@@ -1,5 +1,5 @@
 {% extends "base_minimal_auth.html" %}
-{% block title %}Problems · Wall Display · {{ block.super }}{% endblock %}
+{% block title %}{{ page_title }} · Wall Display · {{ block.super }}{% endblock %}
 {% block extra_head %}
   {% if refresh_seconds %}<meta http-equiv="refresh" content="{{ refresh_seconds }}">{% endif %}
 {% endblock %}
@@ -8,7 +8,24 @@
     <div class="wall-display centered-container">
       <p class="text-muted text-center">{{ error }}</p>
     </div>
+  {% elif mode == "now-playing" %}
+    <div class="column-grid wall-display wall-display--now-playing">
+      {% for column in columns %}
+        <div class="now-playing-location"
+             style="flex-grow: {{ column.sub_columns }}">
+          <h2 class="column-grid__header">{{ column.label }}</h2>
+          <div class="now-playing-grid"
+               style="grid-template-rows: repeat({{ per_column }}, auto)">
+            {% for entry in column.items %}
+              {% include "maintenance/partials/wall_display_now_playing_entry.html" with entry=entry %}
+            {% empty %}
+              <p class="text-muted">{{ empty_message }}</p>
+            {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
   {% else %}
-    {% include "core/partials/column_grid.html" with grid_classes="wall-display" card_template="maintenance/partials/wall_display_entry.html" empty_message="No open problems 🥳" %}
+    {% include "core/partials/column_grid.html" with grid_classes="wall-display" card_template=card_template empty_message=empty_message %}
   {% endif %}
 {% endblock %}

--- a/templates/maintenance/wall_display_board.html
+++ b/templates/maintenance/wall_display_board.html
@@ -2,6 +2,20 @@
 {% block title %}{{ page_title }} · Wall Display · {{ block.super }}{% endblock %}
 {% block extra_head %}
   {% if refresh_seconds %}<meta http-equiv="refresh" content="{{ refresh_seconds }}">{% endif %}
+  {% if mode == "now-playing" and not error %}
+    {# djlint:off #}
+    <style>
+      .wall-display--now-playing .now-playing-grid {
+        grid-template-rows: repeat({{ per_column }}, auto);
+      }
+      {% for column in columns %}
+      .wall-display--now-playing .now-playing-location:nth-of-type({{ forloop.counter }}) {
+        flex-grow: {{ column.sub_columns }};
+      }
+      {% endfor %}
+</style>
+    {# djlint:on #}
+  {% endif %}
 {% endblock %}
 {% block body %}
   {% if error %}
@@ -11,11 +25,9 @@
   {% elif mode == "now-playing" %}
     <div class="column-grid wall-display wall-display--now-playing">
       {% for column in columns %}
-        <div class="now-playing-location"
-             style="flex-grow: {{ column.sub_columns }}">
+        <div class="now-playing-location">
           <h2 class="column-grid__header">{{ column.label }}</h2>
-          <div class="now-playing-grid"
-               style="grid-template-rows: repeat({{ per_column }}, auto)">
+          <div class="now-playing-grid">
             {% for entry in column.items %}
               {% include "maintenance/partials/wall_display_now_playing_entry.html" with entry=entry %}
             {% empty %}

--- a/templates/maintenance/wall_display_setup.html
+++ b/templates/maintenance/wall_display_setup.html
@@ -15,6 +15,15 @@
           action="{% url 'wall-display-board' %}"
           class="form-main">
       <div class="form-field">
+        <label class="form-label" for="mode">Display mode</label>
+        <select id="mode" name="mode" class="form-input">
+          {% for value, label in mode_choices %}
+            <option value="{{ value }}" {% if value == mode %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+        <p class="form-hint">Workshop shows open problems. Now Playing shows machines ready to play.</p>
+      </div>
+      <div class="form-field">
         <label class="form-label">Locations</label>
         <p class="form-hint">Drag to set column order.</p>
         <div data-sortable-locations>
@@ -39,6 +48,17 @@
                placeholder="e.g. 120"
                class="form-input form-input--width-10">
         <p class="form-hint">Auto-refresh in seconds. Minimum 10. Leave blank for no refresh.</p>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="per_column">Machines per sub-column</label>
+        <input type="number"
+               id="per_column"
+               name="per_column"
+               min="1"
+               max="50"
+               value="{{ default_per_column }}"
+               class="form-input form-input--width-10">
+        <p class="form-hint">Now Playing only. Each location splits into sub-columns of this many machines.</p>
       </div>
       <div class="form-actions">
         <button type="submit" class="btn btn--primary" disabled>


### PR DESCRIPTION
## Summary

- Adds a **Now Playing** mode to `/wall/` that shows machines with `operational_status=GOOD` as a dense, scannable lineup for floor displays. Selectable via a dropdown on the setup page; existing **Workshop** mode is the default and is unchanged.
- Each location splits into sub-columns of *N* machines (configurable, default 10, range 1–50). The outer flex container sizes each location proportionally to the number of sub-columns it needs, so a 30-machine location claims more horizontal space than a 5-machine one.
- Machines are sorted oldest manufacturing year first and rendered as `**Name** (Manufacturer, Year)`. No card chrome, no problem-report or log-entry decoration — visitors just see what's ready to play.

## Test plan

- [x] `make test` — 1845 tests pass (47 in the wall-display suite, 14 new for this feature)
- [x] `make quality` — lint + typecheck clean
- [x] Manual smoke at `/wall/`:
  - Workshop mode renders unchanged.
  - Now Playing mode lists working machines, sorted oldest year first, formatted `Name (Manufacturer, Year)`.
  - Adjusting `per_column` changes how many machines fit per sub-column.
  - Locations with more machines claim proportionally more horizontal space.
  - Refresh interval still applies in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wall display adds a "now-playing" mode alongside "workshop": shows working machines by location, ordered oldest-first, with per-location sub-column sizing (clamped/minimum) and configurable machines-per-sub-column; unknown modes fall back to workshop and workshop is the default. Now-playing entries show manufacturer and year formatted succinctly (omitting empty parentheses).

* **Tests**
  * Added coverage for both modes, mode selection/defaults, now-playing filtering/sorting/formatting, empty-state, and layout/per-column behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipfix/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->