### PR TITLE
feat(catalog): year-first format for Now Playing model label

### DIFF
--- a/flipfix/apps/catalog/templatetags/catalog_tags.py
+++ b/flipfix/apps/catalog/templatetags/catalog_tags.py
@@ -77,23 +77,25 @@ def manufacturer_year(model):
 
 @register.filter
 def manufacturer_year_parens(model):
-    """Return '(Manufacturer, Year)' for a machine model, or '' if both blank.
+    """Return '(Year Manufacturer)' for a machine model, or '' if both blank.
 
-    Comma-separated variant used by the Now Playing wall display.
-    Returns an empty string when both fields are blank, so templates
-    can omit the trailing label cleanly.
+    Year-first compact variant used by the Now Playing wall display.
+    Falls back to just one component if only one is set, and returns
+    an empty string when both are blank so templates can omit the
+    trailing label cleanly.
 
     Usage:
         {{ machine.model|manufacturer_year_parens }}
     """
-    parts = []
-    if model.manufacturer:
-        parts.append(model.manufacturer)
-    if model.year:
-        parts.append(str(model.year))
-    if not parts:
-        return ""
-    return f"({', '.join(parts)})"
+    has_year = bool(model.year)
+    has_manufacturer = bool(model.manufacturer)
+    if has_year and has_manufacturer:
+        return f"({model.year} {model.manufacturer})"
+    if has_year:
+        return f"({model.year})"
+    if has_manufacturer:
+        return f"({model.manufacturer})"
+    return ""
 
 
 # ---- Settable pills ---------------------------------------------------------

--- a/flipfix/apps/maintenance/tests/test_wall_display.py
+++ b/flipfix/apps/maintenance/tests/test_wall_display.py
@@ -463,7 +463,7 @@ class WallDisplayBoardNowPlayingTests(SuppressRequestLogsMixin, TestDataMixin, T
         create_machine(slug="taf", name="The Addams Family", location=self.floor, model=model)
         response = self.client.get(self.board_url, {"mode": "now-playing", "location": ["floor"]})
         self.assertContains(response, "The Addams Family")
-        self.assertContains(response, "(Williams, 1994)")
+        self.assertContains(response, "(1994 Williams)")
 
     def test_now_playing_omits_parens_when_neither_present(self):
         """No naked parens when both manufacturer and year are blank."""


### PR DESCRIPTION
## Summary

- Switches the `manufacturer_year_parens` filter output from `(Williams, 1994)` to `(1994 Williams)` — year leads, no comma.
- Single-value cases render as `(Williams)` or `(1994)`; empty stays empty.
- The filter is consumed only by the Now Playing wall display, so the change is isolated to that view.

## Test plan

- [x] `make test` — wall display + catalog suites pass (219 tests)
- [x] `make quality` — lint + typecheck clean
- [ ] Manual: refresh `/wall/board/?mode=now-playing&location=floor` and confirm rows now read `**Name** (1994 Williams)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display format of manufacturer and year information to show year first, followed by manufacturer (e.g., "(1994 Williams)" instead of "(Williams, 1994)") for improved readability on wall displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipfix/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->