### PR TITLE
feat(catalog): add machine Explore page with era-by-year dot chart

### DIFF
--- a/docs/Javascript.md
+++ b/docs/Javascript.md
@@ -186,9 +186,10 @@ These are utility functions called by other components rather than auto-initiali
 
 ### Page-Specific
 
-| File                | Purpose                                           |
-| ------------------- | ------------------------------------------------- |
-| log_entry_detail.js | Auto-save for log entry work date and maintainers |
+| File                | Purpose                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| log_entry_detail.js | Auto-save for log entry work date and maintainers                        |
+| catalog_chart.js    | Machine Explore dot chart (reads `json_script` data, renders inline SVG) |
 
 ## Custom Events
 

--- a/flipfix/apps/catalog/tests/test_explore_view.py
+++ b/flipfix/apps/catalog/tests/test_explore_view.py
@@ -1,0 +1,97 @@
+"""Tests for the machine Explore (collection visualization) view."""
+
+from django.test import TestCase, tag
+from django.urls import reverse
+
+from flipfix.apps.catalog.models import MachineInstance, MachineModel
+from flipfix.apps.core.test_utils import (
+    AccessControlTestCase,
+    create_machine,
+    create_machine_model,
+    create_maintainer_user,
+    create_user,
+)
+
+
+@tag("views")
+class MachineExploreViewAccessTests(AccessControlTestCase):
+    """Access control for the public Explore route."""
+
+    def setUp(self):
+        self.maintainer_user = create_maintainer_user()
+        self.regular_user = create_user()
+        self.url = reverse("machine-explore")
+
+    def test_anonymous_redirected_to_login(self):
+        """Guests are redirected when guest access is disabled (the default)."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_non_maintainer_can_view_public_route(self):
+        self.client.force_login(self.regular_user)
+        self.assertEqual(self.client.get(self.url).status_code, 200)
+
+    def test_maintainer_can_view(self):
+        self.client.force_login(self.maintainer_user)
+        self.assertEqual(self.client.get(self.url).status_code, 200)
+
+
+@tag("views")
+class MachineExploreViewDataTests(TestCase):
+    """The chart payload reflects owned machines and excludes incomplete data."""
+
+    def setUp(self):
+        self.client.force_login(create_maintainer_user())
+        self.url = reverse("machine-explore")
+
+    def _chart(self):
+        return self.client.get(self.url).context
+
+    def test_one_dot_per_instance(self):
+        """Two physical copies of one model produce two dots."""
+        model = create_machine_model(manufacturer="Williams", year=1992, era=MachineModel.Era.SS)
+        create_machine(model=model, slug="twi-1", name="Twilight Zone #1")
+        create_machine(model=model, slug="twi-2", name="Twilight Zone #2")
+
+        chart_data = self._chart()["chart_data"]
+        self.assertEqual(len(chart_data), 2)
+        self.assertTrue(
+            all(d["manufacturer"] == "Williams" and d["year"] == 1992 for d in chart_data)
+        )
+
+    def test_payload_fields_and_labels(self):
+        model = create_machine_model(manufacturer="Bally", year=1980, era=MachineModel.Era.EM)
+        create_machine(
+            model=model,
+            slug="kiss",
+            name="Kiss",
+            operational_status=MachineInstance.OperationalStatus.BROKEN,
+        )
+
+        dot = self._chart()["chart_data"][0]
+        self.assertEqual(dot["name"], "Kiss")
+        self.assertEqual(dot["era"], "EM")
+        self.assertEqual(dot["era_label"], "Electromechanical")
+        self.assertEqual(dot["status_label"], "Broken")
+        self.assertEqual(dot["url"], reverse("maintainer-machine-detail", args=["kiss"]))
+
+    def test_excludes_instances_missing_chart_dimensions(self):
+        """Instances whose model lacks year, manufacturer or era are not charted."""
+        create_machine(
+            model=create_machine_model(manufacturer="Gottlieb", year=1975, era=MachineModel.Era.EM)
+        )
+        create_machine(model=create_machine_model(year=None), slug="no-year")
+        create_machine(model=create_machine_model(manufacturer=""), slug="no-mfr")
+        create_machine(model=create_machine_model(era=""), slug="no-era")
+
+        context = self._chart()
+        self.assertEqual(len(context["chart_data"]), 1)
+        self.assertEqual(context["excluded_count"], 3)
+
+    def test_legend_lists_all_eras(self):
+        legend = self._chart()["legend"]
+        self.assertEqual(
+            [item["era"] for item in legend],
+            [MachineModel.Era.PM, MachineModel.Era.EM, MachineModel.Era.SS],
+        )

--- a/flipfix/apps/catalog/views/explore.py
+++ b/flipfix/apps/catalog/views/explore.py
@@ -30,9 +30,9 @@ class MachineExploreView(TemplateView):
         # Only machines whose model carries all three chart dimensions can be
         # plotted. ``visible()`` select_related's the model, so reading
         # model fields and ``get_*_display()`` below adds no extra queries.
+        owned = MachineInstance.objects.visible()
         instances = (
-            MachineInstance.objects.visible()
-            .filter(model__year__isnull=False)
+            owned.filter(model__year__isnull=False)
             .exclude(model__manufacturer="")
             .exclude(model__era="")
             .order_by("model__manufacturer", "model__year", "model__sort_name")
@@ -54,7 +54,9 @@ class MachineExploreView(TemplateView):
 
         context["chart_data"] = chart_data
         context["legend"] = [{"era": era.value, "label": era.label} for era in MachineModel.Era]
-        context["excluded_count"] = MachineInstance.objects.count() - len(chart_data)
+        # Count exclusions against the same base queryset chart_data is built
+        # from, so the two stay consistent (chart_data is always a subset).
+        context["excluded_count"] = owned.count() - len(chart_data)
         context["meta_description"] = (
             "Explore The Flip's pinball collection by year, manufacturer and technology era."
         )

--- a/flipfix/apps/catalog/views/explore.py
+++ b/flipfix/apps/catalog/views/explore.py
@@ -1,0 +1,61 @@
+"""Views for the machine "Explore" page (collection visualizations)."""
+
+from typing import Any
+
+from django.urls import reverse
+from django.views.generic import TemplateView
+
+from flipfix.apps.catalog.models import MachineInstance, MachineModel
+
+
+class MachineExploreView(TemplateView):
+    """Public page that visualizes the collection.
+
+    The first visualization is a dot chart of physical machines plotted by year
+    (x) and manufacturer (y), colored by technology era. Each dot is one
+    :class:`MachineInstance`, so owning two copies of a title yields two dots.
+
+    The view stays deliberately thin: it emits a flat, library-agnostic list of
+    dot records and lets the client compute scales, manufacturer ordering and
+    stacking. This keeps the layout responsive to viewport width and makes a
+    future swap of the rendering layer (e.g. Observable Plot) a client-only
+    change.
+    """
+
+    template_name = "catalog/explore.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+
+        # Only machines whose model carries all three chart dimensions can be
+        # plotted. ``visible()`` select_related's the model, so reading
+        # model fields and ``get_*_display()`` below adds no extra queries.
+        instances = (
+            MachineInstance.objects.visible()
+            .filter(model__year__isnull=False)
+            .exclude(model__manufacturer="")
+            .exclude(model__era="")
+            .order_by("model__manufacturer", "model__year", "model__sort_name")
+        )
+
+        chart_data = [
+            {
+                "name": instance.short_display_name,
+                "manufacturer": instance.model.manufacturer,
+                "year": instance.model.year,
+                "era": instance.model.era,
+                "era_label": instance.model.get_era_display(),
+                "status": instance.operational_status,
+                "status_label": instance.get_operational_status_display(),
+                "url": reverse("maintainer-machine-detail", args=[instance.slug]),
+            }
+            for instance in instances
+        ]
+
+        context["chart_data"] = chart_data
+        context["legend"] = [{"era": era.value, "label": era.label} for era in MachineModel.Era]
+        context["excluded_count"] = MachineInstance.objects.count() - len(chart_data)
+        context["meta_description"] = (
+            "Explore The Flip's pinball collection by year, manufacturer and technology era."
+        )
+        return context

--- a/flipfix/static/core/catalog_chart.dom.test.js
+++ b/flipfix/static/core/catalog_chart.dom.test.js
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest';
 
-const { renderChart } = require('./catalog_chart.js');
+const { renderChart, init } = require('./catalog_chart.js');
 
 const dot = (manufacturer, year, era, extra = {}) => ({
   name: `${manufacturer} ${year}`,
@@ -75,5 +75,35 @@ describe('renderChart', () => {
     renderChart(mount, []);
     expect(mount.querySelector('svg')).toBeNull();
     expect(mount.textContent).toContain('No machines to chart');
+  });
+});
+
+describe('init (progressive enhancement)', () => {
+  const setup = (dots) => {
+    document.body.innerHTML = `
+      <div data-machine-chart id="machine-chart"></div>
+      <script type="application/json" id="machine-chart-data">${JSON.stringify(dots)}</script>
+      <table id="machine-chart-table"><tbody></tbody></table>
+    `;
+    return document.querySelector('[data-machine-chart]');
+  };
+
+  it('hides the fallback table once the chart renders', () => {
+    const mount = setup([dot('Bally', 1980, 'EM')]);
+    const table = document.getElementById('machine-chart-table');
+    expect(table.classList.contains('visually-hidden')).toBe(false);
+
+    init(mount);
+    expect(mount.querySelector('svg')).not.toBeNull();
+    expect(table.classList.contains('visually-hidden')).toBe(true);
+  });
+
+  it('leaves the table visible when there is nothing to chart', () => {
+    const mount = setup([]);
+    init(mount);
+    expect(mount.querySelector('svg')).toBeNull();
+    expect(
+      document.getElementById('machine-chart-table').classList.contains('visually-hidden')
+    ).toBe(false);
   });
 });

--- a/flipfix/static/core/catalog_chart.dom.test.js
+++ b/flipfix/static/core/catalog_chart.dom.test.js
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const { renderChart } = require('./catalog_chart.js');
+
+const dot = (manufacturer, year, era, extra = {}) => ({
+  name: `${manufacturer} ${year}`,
+  manufacturer,
+  year,
+  era,
+  era_label: era,
+  status: 'good',
+  status_label: 'Good',
+  url: `/machines/${manufacturer}-${year}/`,
+  ...extra,
+});
+
+describe('renderChart', () => {
+  let mount;
+
+  beforeEach(() => {
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+  });
+
+  it('draws one linked, era-colored circle per dot', () => {
+    renderChart(mount, [
+      dot('Williams', 1992, 'SS'),
+      dot('Williams', 1992, 'SS'),
+      dot('Bally', 1980, 'EM'),
+    ]);
+
+    const circles = mount.querySelectorAll('circle.machine-chart__dot');
+    expect(circles).toHaveLength(3);
+
+    const links = mount.querySelectorAll('a.machine-chart__dot-link');
+    expect(links).toHaveLength(3);
+    expect(links[0].getAttribute('href')).toContain('/machines/');
+    expect(links[0].getAttribute('aria-label')).toContain('Williams 1992');
+
+    // Era drives the dot class.
+    expect(mount.querySelectorAll('.machine-chart__dot--ss')).toHaveLength(2);
+    expect(mount.querySelectorAll('.machine-chart__dot--em')).toHaveLength(1);
+  });
+
+  it('stacks same-cell dots at the same x but different y', () => {
+    renderChart(mount, [dot('Williams', 1992, 'SS'), dot('Williams', 1992, 'SS')]);
+    const circles = [...mount.querySelectorAll('circle')];
+    expect(circles[0].getAttribute('cx')).toBe(circles[1].getAttribute('cx'));
+    expect(circles[0].getAttribute('cy')).not.toBe(circles[1].getAttribute('cy'));
+  });
+
+  it('renders a row label per manufacturer and decade gridlines', () => {
+    renderChart(mount, [dot('Bally', 1980, 'EM'), dot('Williams', 1992, 'SS')]);
+    const rowLabels = [...mount.querySelectorAll('text.machine-chart__row-label')].map(
+      (el) => el.textContent
+    );
+    expect(rowLabels).toContain('Bally');
+    expect(rowLabels).toContain('Williams');
+    expect(mount.querySelectorAll('line.machine-chart__gridline').length).toBeGreaterThan(0);
+  });
+
+  it('reveals the hover card with machine detail on focus', () => {
+    renderChart(mount, [dot('Gottlieb', 1975, 'EM', { era_label: 'Electromechanical' })]);
+    const card = mount.querySelector('.chart-card');
+    expect(card.classList.contains('hidden')).toBe(true);
+
+    mount.querySelector('a.machine-chart__dot-link').dispatchEvent(new Event('mouseenter'));
+    expect(card.classList.contains('hidden')).toBe(false);
+    expect(card.textContent).toContain('Gottlieb 1975');
+    expect(card.textContent).toContain('Electromechanical');
+  });
+
+  it('shows an empty message when there are no dots', () => {
+    renderChart(mount, []);
+    expect(mount.querySelector('svg')).toBeNull();
+    expect(mount.textContent).toContain('No machines to chart');
+  });
+});

--- a/flipfix/static/core/catalog_chart.js
+++ b/flipfix/static/core/catalog_chart.js
@@ -1,0 +1,307 @@
+/**
+ * Machine "Explore" dot chart.
+ *
+ * Plots physical machines by year (x) and manufacturer (y), colored by
+ * technology era. Each dot is one machine; machines sharing a manufacturer and
+ * year stack vertically.
+ *
+ * Data prep lives in pure, exported helpers (groupDots / orderManufacturers /
+ * yearScale / yearExtent / decadeTicks). All drawing is funnelled through the
+ * single `renderChart` boundary so the rendering layer can later be swapped
+ * (e.g. for Observable Plot) without disturbing data prep or the hover card.
+ */
+(function (exports) {
+  'use strict';
+
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+
+  // Layout constants (px).
+  const DOT_RADIUS = 7;
+  const DOT_PITCH = 18; // vertical center-to-center distance for stacked dots
+  const ROW_PADDING = 10;
+  const ROW_MIN_HEIGHT = 34;
+  const LABEL_GUTTER = 140; // left space for manufacturer names
+  const AXIS_HEIGHT = 28; // bottom space for year labels
+  const TOP_PAD = 10;
+  const RIGHT_PAD = 24;
+  const MIN_DECADE_WIDTH = 70;
+
+  // ---- Pure helpers (unit tested) ----------------------------------------
+
+  /**
+   * Group dots by manufacturer, then by year.
+   * @returns {Array<{manufacturer, total, maxStack, stacks: Array<{year, dots}>}>}
+   *   one entry per manufacturer; `stacks` sorted ascending by year.
+   */
+  function groupDots(dots) {
+    const byManufacturer = new Map();
+    for (const dot of dots) {
+      if (!byManufacturer.has(dot.manufacturer)) {
+        byManufacturer.set(dot.manufacturer, new Map());
+      }
+      const byYear = byManufacturer.get(dot.manufacturer);
+      if (!byYear.has(dot.year)) byYear.set(dot.year, []);
+      byYear.get(dot.year).push(dot);
+    }
+
+    const groups = [];
+    for (const [manufacturer, byYear] of byManufacturer) {
+      const stacks = [...byYear.entries()]
+        .map(([year, stackDots]) => ({ year, dots: stackDots }))
+        .sort((a, b) => a.year - b.year);
+      const total = stacks.reduce((sum, s) => sum + s.dots.length, 0);
+      const maxStack = stacks.reduce((max, s) => Math.max(max, s.dots.length), 0);
+      groups.push({ manufacturer, total, maxStack, stacks });
+    }
+    return groups;
+  }
+
+  /** Order manufacturer rows: most machines first, ties broken alphabetically. */
+  function orderManufacturers(groups) {
+    return [...groups].sort((a, b) => {
+      if (b.total !== a.total) return b.total - a.total;
+      return a.manufacturer.localeCompare(b.manufacturer);
+    });
+  }
+
+  /** Min/max year across dots, or null when there are none. */
+  function yearExtent(dots) {
+    if (!dots.length) return null;
+    let min = Infinity;
+    let max = -Infinity;
+    for (const dot of dots) {
+      if (dot.year < min) min = dot.year;
+      if (dot.year > max) max = dot.year;
+    }
+    return { min, max };
+  }
+
+  /**
+   * Build a linear year→pixel scale over [0, width].
+   * Collapses to the midpoint when the domain is a single year.
+   */
+  function yearScale(minYear, maxYear, width) {
+    if (maxYear === minYear) return () => width / 2;
+    const span = maxYear - minYear;
+    return (year) => ((year - minYear) / span) * width;
+  }
+
+  /**
+   * Chart x-domain: from the earliest machine to the current year, so the axis
+   * always runs through to "now". Guards against future-dated data by never
+   * clipping below the data's own maximum.
+   */
+  function chartYearRange(dots, currentYear) {
+    const extent = yearExtent(dots);
+    if (!extent) return null;
+    return { min: extent.min, max: Math.max(currentYear, extent.max) };
+  }
+
+  /** Decade-boundary years within [minYear, maxYear] inclusive. */
+  function decadeTicks(minYear, maxYear) {
+    const ticks = [];
+    for (let y = Math.ceil(minYear / 10) * 10; y <= maxYear; y += 10) {
+      ticks.push(y);
+    }
+    return ticks;
+  }
+
+  /** Height of a manufacturer row given its tallest stack. */
+  function rowHeight(maxStack) {
+    const stackSpan = (Math.max(1, maxStack) - 1) * DOT_PITCH + DOT_RADIUS * 2;
+    return Math.max(ROW_MIN_HEIGHT, stackSpan + ROW_PADDING * 2);
+  }
+
+  // ---- Rendering (DOM; browser only) -------------------------------------
+
+  function svgEl(name, attrs) {
+    const el = document.createElementNS(SVG_NS, name);
+    for (const [key, value] of Object.entries(attrs)) {
+      el.setAttribute(key, String(value));
+    }
+    return el;
+  }
+
+  function buildHoverCard(mountEl) {
+    const card = document.createElement('div');
+    card.className = 'chart-card hidden';
+    card.setAttribute('role', 'tooltip');
+    mountEl.appendChild(card);
+    return card;
+  }
+
+  function showCard(card, mountEl, circle, dot) {
+    card.innerHTML = '';
+    const title = document.createElement('div');
+    title.className = 'chart-card__title';
+    title.textContent = dot.name;
+    const meta = document.createElement('div');
+    meta.className = 'chart-card__meta';
+    meta.textContent = `${dot.manufacturer} · ${dot.year}`;
+    const tags = document.createElement('div');
+    tags.className = 'chart-card__tags';
+    tags.textContent = `${dot.era_label} · ${dot.status_label}`;
+    card.append(title, meta, tags);
+    card.classList.remove('hidden');
+
+    // Anchor the card to the dot, accounting for horizontal scroll. Clamp so it
+    // stays within the (possibly wider-than-viewport) chart canvas.
+    const chartRect = mountEl.getBoundingClientRect();
+    const dotRect = circle.getBoundingClientRect();
+    const left = dotRect.left - chartRect.left + mountEl.scrollLeft + DOT_RADIUS;
+    const top = dotRect.top - chartRect.top + mountEl.scrollTop;
+    const maxLeft = mountEl.scrollWidth - card.offsetWidth - 8;
+    card.style.left = `${Math.max(8, Math.min(left, maxLeft))}px`;
+    card.style.top = `${Math.max(8, top - card.offsetHeight - 8)}px`;
+  }
+
+  function hideCard(card) {
+    card.classList.add('hidden');
+  }
+
+  function renderChart(mountEl, dots) {
+    mountEl.innerHTML = '';
+
+    if (!dots.length) {
+      const empty = document.createElement('p');
+      empty.className = 'text-muted';
+      empty.textContent = 'No machines to chart yet.';
+      mountEl.appendChild(empty);
+      return;
+    }
+
+    const groups = orderManufacturers(groupDots(dots));
+    const extent = chartYearRange(dots, new Date().getFullYear());
+    const ticks = decadeTicks(extent.min, extent.max);
+    const axisYears = ticks.length
+      ? ticks
+      : extent.min === extent.max
+        ? [extent.min]
+        : [extent.min, extent.max];
+
+    const containerWidth = mountEl.clientWidth || 800;
+    const minWidth = LABEL_GUTTER + RIGHT_PAD + Math.max(1, axisYears.length) * MIN_DECADE_WIDTH;
+    const svgWidth = Math.max(containerWidth, minWidth);
+    const plotWidth = svgWidth - LABEL_GUTTER - RIGHT_PAD;
+    const xScale = yearScale(extent.min, extent.max, plotWidth);
+    const x = (year) => LABEL_GUTTER + xScale(year);
+
+    const rowHeights = groups.map((g) => rowHeight(g.maxStack));
+    const plotHeight = rowHeights.reduce((sum, h) => sum + h, 0);
+    const svgHeight = TOP_PAD + plotHeight + AXIS_HEIGHT;
+
+    const svg = svgEl('svg', {
+      class: 'machine-chart__svg',
+      width: svgWidth,
+      height: svgHeight,
+      viewBox: `0 0 ${svgWidth} ${svgHeight}`,
+      role: 'img',
+      'aria-label': 'Scatter chart of machines by year and manufacturer, colored by technology era',
+    });
+
+    // Decade gridlines + year labels.
+    for (const year of axisYears) {
+      const px = x(year);
+      svg.appendChild(
+        svgEl('line', {
+          class: 'machine-chart__gridline',
+          x1: px,
+          y1: TOP_PAD,
+          x2: px,
+          y2: TOP_PAD + plotHeight,
+        })
+      );
+      const label = svgEl('text', {
+        class: 'machine-chart__year-label',
+        x: px,
+        y: TOP_PAD + plotHeight + 18,
+        'text-anchor': 'middle',
+      });
+      label.textContent = String(year);
+      svg.appendChild(label);
+    }
+
+    const card = buildHoverCard(mountEl);
+
+    // Manufacturer rows.
+    let rowTop = TOP_PAD;
+    groups.forEach((group, rowIndex) => {
+      const height = rowHeights[rowIndex];
+      const baseline = rowTop + height - ROW_PADDING - DOT_RADIUS;
+
+      const label = svgEl('text', {
+        class: 'machine-chart__row-label',
+        x: LABEL_GUTTER - 10,
+        y: rowTop + height / 2,
+        'text-anchor': 'end',
+        'dominant-baseline': 'middle',
+      });
+      label.textContent = group.manufacturer;
+      svg.appendChild(label);
+
+      for (const stack of group.stacks) {
+        stack.dots.forEach((dot, depth) => {
+          // Each dot is a link to its machine; the hover/focus card shows detail.
+          const link = svgEl('a', {
+            class: 'machine-chart__dot-link',
+            href: dot.url,
+            'aria-label': `${dot.name}, ${dot.manufacturer} ${dot.year}, ${dot.era_label}, ${dot.status_label}`,
+          });
+          const circle = svgEl('circle', {
+            class: `machine-chart__dot machine-chart__dot--${dot.era.toLowerCase()}`,
+            cx: x(dot.year),
+            cy: baseline - depth * DOT_PITCH,
+            r: DOT_RADIUS,
+          });
+          link.appendChild(circle);
+          const show = () => showCard(card, mountEl, circle, dot);
+          link.addEventListener('mouseenter', show);
+          link.addEventListener('focus', show);
+          link.addEventListener('mouseleave', () => hideCard(card));
+          link.addEventListener('blur', () => hideCard(card));
+          svg.appendChild(link);
+        });
+      }
+      rowTop += height;
+    });
+
+    mountEl.appendChild(svg);
+  }
+
+  function init(mountEl) {
+    const dataEl = document.getElementById('machine-chart-data');
+    if (!dataEl) return;
+    let dots;
+    try {
+      dots = JSON.parse(dataEl.textContent);
+    } catch (err) {
+      return;
+    }
+    renderChart(mountEl, dots);
+
+    // Redraw on resize so the year axis re-fits the viewport.
+    let resizeTimer;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => renderChart(mountEl, dots), 150);
+    });
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+      const mountEl = document.querySelector('[data-machine-chart]');
+      if (mountEl) init(mountEl);
+    });
+  }
+
+  if (exports) {
+    exports.groupDots = groupDots;
+    exports.orderManufacturers = orderManufacturers;
+    exports.yearExtent = yearExtent;
+    exports.chartYearRange = chartYearRange;
+    exports.yearScale = yearScale;
+    exports.decadeTicks = decadeTicks;
+    exports.rowHeight = rowHeight;
+    exports.renderChart = renderChart;
+  }
+})(typeof module !== 'undefined' ? module.exports : null);

--- a/flipfix/static/core/catalog_chart.js
+++ b/flipfix/static/core/catalog_chart.js
@@ -279,6 +279,14 @@
     }
     renderChart(mountEl, dots);
 
+    // Progressive enhancement: the data table is visible by default (the no-JS
+    // fallback). Now that the SVG has rendered, demote it to a screen-reader-only
+    // representation so it stays available to assistive tech without duplicating
+    // the chart visually.
+    if (mountEl.querySelector('svg')) {
+      document.getElementById('machine-chart-table')?.classList.add('visually-hidden');
+    }
+
     // Redraw on resize so the year axis re-fits the viewport.
     let resizeTimer;
     window.addEventListener('resize', () => {
@@ -303,5 +311,6 @@
     exports.decadeTicks = decadeTicks;
     exports.rowHeight = rowHeight;
     exports.renderChart = renderChart;
+    exports.init = init;
   }
 })(typeof module !== 'undefined' ? module.exports : null);

--- a/flipfix/static/core/catalog_chart.test.js
+++ b/flipfix/static/core/catalog_chart.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+
+const {
+  groupDots,
+  orderManufacturers,
+  yearExtent,
+  chartYearRange,
+  yearScale,
+  decadeTicks,
+  rowHeight,
+} = require('./catalog_chart.js');
+
+const dot = (manufacturer, year, era = 'SS') => ({
+  name: `${manufacturer} ${year}`,
+  manufacturer,
+  year,
+  era,
+  era_label: era,
+  status: 'good',
+  status_label: 'Good',
+  url: '/machines/x/',
+});
+
+describe('groupDots', () => {
+  it('groups by manufacturer then year and stacks same-cell machines', () => {
+    const groups = groupDots([
+      dot('Williams', 1992),
+      dot('Williams', 1992),
+      dot('Williams', 1990),
+      dot('Bally', 1980),
+    ]);
+    const williams = groups.find((g) => g.manufacturer === 'Williams');
+    expect(williams.total).toBe(3);
+    expect(williams.maxStack).toBe(2);
+    // Stacks are sorted ascending by year.
+    expect(williams.stacks.map((s) => s.year)).toEqual([1990, 1992]);
+    expect(williams.stacks.find((s) => s.year === 1992).dots).toHaveLength(2);
+  });
+
+  it('returns an empty array for no dots', () => {
+    expect(groupDots([])).toEqual([]);
+  });
+});
+
+describe('orderManufacturers', () => {
+  it('orders by total descending, then alphabetically', () => {
+    const groups = groupDots([
+      dot('Stern', 2001),
+      dot('Bally', 1980),
+      dot('Bally', 1981),
+      dot('Atari', 1979),
+      dot('Atari', 1980),
+    ]);
+    expect(orderManufacturers(groups).map((g) => g.manufacturer)).toEqual([
+      'Atari', // 2, alphabetically before Bally
+      'Bally', // 2
+      'Stern', // 1
+    ]);
+  });
+});
+
+describe('yearExtent', () => {
+  it('returns min and max years', () => {
+    expect(yearExtent([dot('A', 1975), dot('B', 1992), dot('C', 1968)])).toEqual({
+      min: 1968,
+      max: 1992,
+    });
+  });
+
+  it('returns null with no dots', () => {
+    expect(yearExtent([])).toBeNull();
+  });
+});
+
+describe('chartYearRange', () => {
+  it('extends the domain to the current year even when data is older', () => {
+    expect(chartYearRange([dot('A', 1975), dot('B', 1992)], 2026)).toEqual({
+      min: 1975,
+      max: 2026,
+    });
+  });
+
+  it('never clips below the data maximum (future-dated data)', () => {
+    expect(chartYearRange([dot('A', 1975), dot('B', 2030)], 2026)).toEqual({
+      min: 1975,
+      max: 2030,
+    });
+  });
+
+  it('returns null with no dots', () => {
+    expect(chartYearRange([], 2026)).toBeNull();
+  });
+});
+
+describe('yearScale', () => {
+  it('maps the domain endpoints to 0 and width', () => {
+    const x = yearScale(1970, 1990, 200);
+    expect(x(1970)).toBe(0);
+    expect(x(1990)).toBe(200);
+    expect(x(1980)).toBe(100);
+  });
+
+  it('collapses a single-year domain to the midpoint', () => {
+    const x = yearScale(1985, 1985, 200);
+    expect(x(1985)).toBe(100);
+  });
+});
+
+describe('decadeTicks', () => {
+  it('returns decade boundaries within the range', () => {
+    expect(decadeTicks(1968, 1992)).toEqual([1970, 1980, 1990]);
+  });
+
+  it('is empty when no decade boundary falls in range', () => {
+    expect(decadeTicks(1971, 1978)).toEqual([]);
+  });
+});
+
+describe('rowHeight', () => {
+  it('honours a minimum height for short stacks', () => {
+    expect(rowHeight(1)).toBeGreaterThanOrEqual(34);
+  });
+
+  it('grows with the tallest stack', () => {
+    expect(rowHeight(4)).toBeGreaterThan(rowHeight(1));
+  });
+});

--- a/flipfix/static/core/styles.css
+++ b/flipfix/static/core/styles.css
@@ -3520,6 +3520,27 @@ a.stat:focus-visible {
   font-size: var(--text-sm);
 }
 
+/* No-JS fallback table (JS demotes it to .visually-hidden once the SVG renders) */
+.machine-chart__table {
+  width: 100%;
+  margin-top: var(--space-4);
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.machine-chart__table caption {
+  text-align: left;
+  font-weight: var(--font-semibold);
+  margin-bottom: var(--space-2);
+}
+
+.machine-chart__table th,
+.machine-chart__table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border-soft);
+}
+
 /* Hover / focus detail card */
 .chart-card {
   position: absolute;

--- a/flipfix/static/core/styles.css
+++ b/flipfix/static/core/styles.css
@@ -219,6 +219,11 @@ table {
   --color-priority-major-text: #c2410c;
   --color-priority-major-border: #fdba74;
 
+  /* Technology era (chart) — Okabe-Ito palette, colorblind-safe */
+  --color-era-pm: #009e73; /* Pure Mechanical */
+  --color-era-em: #e69f00; /* Electromechanical */
+  --color-era-ss: #0072b2; /* Solid State */
+
   /* Inputs / avatar */
   --color-input-bg: #ffffff;
   --color-input-border: #d1d5db;
@@ -282,6 +287,11 @@ table {
     --color-priority-major-bg: #2d2014;
     --color-priority-major-text: #fb923c;
     --color-priority-major-border: #4a301a;
+
+    /* Technology era — lifted for contrast on dark surfaces */
+    --color-era-pm: #1cc796;
+    --color-era-em: #f0b53a;
+    --color-era-ss: #4daafc;
 
     --color-input-bg: #2b2b2b;
     --color-input-border: #404040;
@@ -3385,4 +3395,158 @@ a.stat:focus-visible {
   width: 1.25em;
   vertical-align: middle;
   margin-right: var(--space-1);
+}
+
+/* ========================================
+   MACHINE EXPLORE CHART
+   ======================================== */
+
+.explore-header {
+  margin: var(--space-4) 0 var(--space-3);
+}
+
+.explore-header__title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  margin: 0;
+}
+
+.explore-header__lead {
+  color: var(--color-text-muted);
+  margin: var(--space-1) 0 0;
+}
+
+/* Era color key */
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  list-style: none;
+  margin: 0 0 var(--space-3);
+  padding: 0;
+}
+
+.chart-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.chart-legend__swatch {
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.chart-legend__swatch--pm {
+  background: var(--color-era-pm);
+}
+
+.chart-legend__swatch--em {
+  background: var(--color-era-em);
+}
+
+.chart-legend__swatch--ss {
+  background: var(--color-era-ss);
+}
+
+/* Chart canvas (scrolls horizontally when wider than the viewport) */
+.machine-chart {
+  position: relative;
+  overflow-x: auto;
+}
+
+.machine-chart__svg {
+  display: block;
+}
+
+.machine-chart__gridline {
+  stroke: var(--color-border-soft);
+  stroke-width: 1;
+}
+
+.machine-chart__year-label,
+.machine-chart__row-label {
+  font-family: var(--font-family);
+  font-size: var(--text-xs);
+  fill: var(--color-text-muted);
+}
+
+.machine-chart__row-label {
+  fill: var(--color-text-primary);
+  font-weight: var(--font-medium);
+}
+
+.machine-chart__dot {
+  stroke: var(--color-surface);
+  stroke-width: 1.5;
+  transition: stroke 0.12s ease;
+}
+
+.machine-chart__dot--pm {
+  fill: var(--color-era-pm);
+}
+
+.machine-chart__dot--em {
+  fill: var(--color-era-em);
+}
+
+.machine-chart__dot--ss {
+  fill: var(--color-era-ss);
+}
+
+.machine-chart__dot-link {
+  cursor: pointer;
+}
+
+.machine-chart__dot-link:hover .machine-chart__dot {
+  stroke: var(--color-text-primary);
+}
+
+.machine-chart__dot-link:focus-visible {
+  outline: none;
+}
+
+.machine-chart__dot-link:focus-visible .machine-chart__dot {
+  stroke: var(--color-input-focus);
+  stroke-width: 3;
+}
+
+.machine-chart__note {
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+}
+
+/* Hover / focus detail card */
+.chart-card {
+  position: absolute;
+  z-index: 100;
+  min-width: 10rem;
+  max-width: 16rem;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+}
+
+.chart-card__title {
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.chart-card__meta {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin-top: var(--space-0-5);
+}
+
+.chart-card__tags {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
 }

--- a/flipfix/urls.py
+++ b/flipfix/urls.py
@@ -17,6 +17,7 @@ from flipfix.apps.accounts.views import (
     UserProfileDetailView,
     invitation_register,
 )
+from flipfix.apps.catalog.views.explore import MachineExploreView
 from flipfix.apps.catalog.views.machines import (
     MachineCreateLandingView,
     MachineCreateModelDoesNotExistView,
@@ -337,6 +338,10 @@ urlpatterns = [
     ###
     # List all machines
     path("machines/", MachineListView.as_view(), name="maintainer-machine-list", access="public"),
+    # Explore: collection visualizations (must precede the <slug> catch route)
+    path(
+        "machines/explore/", MachineExploreView.as_view(), name="machine-explore", access="public"
+    ),
     # Landing page: select model
     path("machines/new/", MachineCreateLandingView.as_view(), name="machine-create-landing"),
     # Create new model + instance

--- a/templates/catalog/explore.html
+++ b/templates/catalog/explore.html
@@ -29,8 +29,10 @@
       {{ excluded_count }} machine{{ excluded_count|pluralize }} not shown (missing year, manufacturer or era).
     </p>
   {% endif %}
-  <!-- Accessible / no-JS fallback: the same data as a table -->
-  <table class="visually-hidden">
+  <!-- Accessible / no-JS fallback: visible by default; catalog_chart.js hides it
+       (visually-hidden) once the SVG renders, so it stays available to screen
+       readers and to sighted users when JavaScript is unavailable. -->
+  <table id="machine-chart-table" class="machine-chart__table">
     <caption>Machines by year, manufacturer and technology era</caption>
     <thead>
       <tr>

--- a/templates/catalog/explore.html
+++ b/templates/catalog/explore.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}Explore · {{ block.super }}{% endblock %}
+{% block content %}
+  <!-- BREADCRUMBS -->
+  <nav class="breadcrumbs breadcrumbs--responsive">
+    <a href="{% url 'maintainer-machine-list' %}">Machines</a>
+    <span>Explore</span>
+  </nav>
+  <header class="explore-header">
+    <h1 class="explore-header__title">Explore the collection</h1>
+    <p class="explore-header__lead">Every machine plotted by year and manufacturer, colored by technology era.</p>
+  </header>
+  <!-- LEGEND: era color key (labels carry the meaning, not color alone) -->
+  <ul class="chart-legend" aria-label="Technology era color key">
+    {% for item in legend %}
+      <li class="chart-legend__item">
+        <span class="chart-legend__swatch chart-legend__swatch--{{ item.era|lower }}"
+              aria-hidden="true"></span>
+        {{ item.label }}
+      </li>
+    {% endfor %}
+  </ul>
+  <!-- CHART: rendered into the mount point by catalog_chart.js -->
+  <div class="machine-chart" id="machine-chart" data-machine-chart></div>
+  {{ chart_data|json_script:"machine-chart-data" }}
+  {% if excluded_count %}
+    <p class="machine-chart__note text-muted">
+      {{ excluded_count }} machine{{ excluded_count|pluralize }} not shown (missing year, manufacturer or era).
+    </p>
+  {% endif %}
+  <!-- Accessible / no-JS fallback: the same data as a table -->
+  <table class="visually-hidden">
+    <caption>Machines by year, manufacturer and technology era</caption>
+    <thead>
+      <tr>
+        <th scope="col">Machine</th>
+        <th scope="col">Manufacturer</th>
+        <th scope="col">Year</th>
+        <th scope="col">Era</th>
+        <th scope="col">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for dot in chart_data %}
+        <tr>
+          <td>
+            <a href="{{ dot.url }}">{{ dot.name }}</a>
+          </td>
+          <td>{{ dot.manufacturer }}</td>
+          <td>{{ dot.year }}</td>
+          <td>{{ dot.era_label }}</td>
+          <td>{{ dot.status_label }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{% static 'core/catalog_chart.js' %}" defer></script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds a public **Explore** page at `/machines/explore/` that visualizes the collection as a dot chart:

- **x-axis** = year of manufacture (timeline runs through to the current year)
- **y-axis** = manufacturer (rows ordered by count, then alphabetically)
- **dot color** = technology era — Pure Mechanical / Electromechanical / Solid State
- **stacking** = machines sharing a manufacturer + year stack vertically
- **hover/focus** = a detail card linking to the machine

Each dot is one physical `MachineInstance`, so owning two copies of a title shows two dots. No schema changes — `manufacturer`, `year`, and `era` already live on `MachineModel`.

## Design notes

- **Thin view**: `MachineExploreView` (`TemplateView`, `access="public"`) emits a flat, library-agnostic dot payload via `json_script`; the client computes scales, ordering and stacking. This keeps the layout responsive and leaves a clean swap path to a charting library (e.g. Observable Plot) later — all drawing is funnelled through a single `renderChart()` boundary.
- **No charting dependency**: hand-built inline SVG in a vanilla-JS IIFE, matching project conventions (`docs/Javascript.md`).
- **Accessibility**: colorblind-safe Okabe-Ito era palette, keyboard-reachable dot links, per-dot `aria-label`s, a legend whose labels (not just color) carry meaning, and a visually-hidden data-table fallback for screen readers / no-JS.
- **Not in the top nav** (reachable by URL) for now — the nav is already crowded.

## Known follow-ups (not in this PR)

- The Explore page isn't linked anywhere yet.
- The read-only machine API (`/api/v1/machines/`) doesn't expose `era`; we plan to extend it so machine data (incl. era) can be imported into local dev. The chart consumes `era` directly from the DB, so this only affects API-based data import.
- `manufacturer` is free text, so spelling variants render as separate rows.

## Testing

- **Python** (`test_explore_view.py`): public + maintainer access, payload correctness, one-dot-per-instance, exclusion of machines missing year/manufacturer/era, label correctness, legend.
- **JS** (`catalog_chart.test.js`): pure helpers — grouping, ordering, year scale/extent, current-year extension + future-data guard, decade ticks, row height.
- **JS jsdom** (`catalog_chart.dom.test.js`): real SVG render path — circle count, links/hrefs/aria-labels, era classes, vertical stacking, row labels, gridlines, hover-card reveal, empty state.
- `make quality` clean (ruff, djlint, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Machine Explore page featuring an interactive dot chart visualization that displays machines organized by manufacturer and year.
  * Each machine is represented as a color-coded dot based on its technology era, with hover details and links to individual machine pages.
  * Includes an era-based legend and handles missing data gracefully.

* **Documentation**
  * Updated documentation to reflect the new chart component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipfix/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->