### PR TITLE
feat(api): expose catalog metadata + add pull_sample_machines command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ TRANSCODING_UPLOAD_TOKEN=your-local-dev-token-here
 # Not that you need one, but generate a secure token by running:
 # python -c 'import secrets; print(secrets.token_urlsafe(32))'
 
+# Refreshing local sample data from production (maintainers only)
+# Used by `python manage.py pull_sample_machines` to rewrite the committed
+# sample-data fixture from the live collection. Get a key from
+# Django Admin → Core → API keys. Leave SAMPLE_DATA_API_KEY blank if you don't
+# need to regenerate sample data.
+SAMPLE_DATA_API_URL=https://flipfix.theflip.museum
+SAMPLE_DATA_API_KEY=
+
 # OAuth2/OIDC Provider (SSO for theflip.museum apps)
 # RSA private key for signing OIDC tokens. Generate by running:
 # python -c "from cryptography.hazmat.primitives.asymmetric import rsa; from cryptography.hazmat.primitives import serialization; key = rsa.generate_private_key(65537, 2048); print(key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.TraditionalOpenSSL, serialization.NoEncryption()).decode())"

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ help:
 	@echo "  make migrations     - Create new migrations"
 	@echo "  make superuser      - Create superuser"
 	@echo "  make sample-data    - Create sample data (dev only)"
+	@echo "  make pull-sample-machines - Refresh machines.json fixture from prod API (needs SAMPLE_DATA_API_KEY)"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  make agent-docs     - Regenerate CLAUDE.md and AGENTS.md from source"
@@ -109,6 +110,10 @@ runbot:
 .PHONY: sample-data
 sample-data:
 	$(PYTHON) manage.py create_sample_data
+
+.PHONY: pull-sample-machines
+pull-sample-machines:
+	$(PYTHON) manage.py pull_sample_machines
 
 .PHONY: lint
 lint:

--- a/docs/API.md
+++ b/docs/API.md
@@ -63,7 +63,14 @@ curl -H "Authorization: Bearer <key>" https://flipfix.example.com/api/v1/machine
       "model": {
         "name": "Medieval Madness",
         "manufacturer": "Williams",
-        "year": 1997
+        "year": 1997,
+        "month": 6,
+        "era": "SS",
+        "system": "WPC-95",
+        "scoring": "points",
+        "flipper_count": 2,
+        "ipdb_id": 4032,
+        "pinside_rating": 9.1
       }
     }
   ]
@@ -72,18 +79,25 @@ curl -H "Authorization: Bearer <key>" https://flipfix.example.com/api/v1/machine
 
 **Field reference:**
 
-| Field                | Type        | Description                                   |
-| -------------------- | ----------- | --------------------------------------------- |
-| `asset_id`           | string      | Unique asset identifier (e.g., `M0001`)       |
-| `name`               | string      | Display name of the machine instance          |
-| `short_name`         | string/null | Short name for compact displays               |
-| `slug`               | string      | URL-friendly identifier                       |
-| `serial_number`      | string      | Manufacturer serial number (may be empty)     |
-| `operational_status` | string      | One of: `good`, `fixing`, `broken`, `unknown` |
-| `location`           | string/null | Location name, or null if unassigned          |
-| `model.name`         | string      | Machine model name                            |
-| `model.manufacturer` | string      | Manufacturer name (may be empty)              |
-| `model.year`         | int/null    | Year of manufacture                           |
+| Field                  | Type        | Description                                     |
+| ---------------------- | ----------- | ----------------------------------------------- |
+| `asset_id`             | string      | Unique asset identifier (e.g., `M0001`)         |
+| `name`                 | string      | Display name of the machine instance            |
+| `short_name`           | string/null | Short name for compact displays                 |
+| `slug`                 | string      | URL-friendly identifier                         |
+| `serial_number`        | string      | Manufacturer serial number (may be empty)       |
+| `operational_status`   | string      | One of: `good`, `fixing`, `broken`, `unknown`   |
+| `location`             | string/null | Location name, or null if unassigned            |
+| `model.name`           | string      | Machine model name                              |
+| `model.manufacturer`   | string      | Manufacturer name (may be empty)                |
+| `model.year`           | int/null    | Year of manufacture                             |
+| `model.month`          | int/null    | Month of manufacture (1–12)                     |
+| `model.era`            | string      | Technology era: `PM`, `EM`, `SS` (may be empty) |
+| `model.system`         | string      | Electronic system, e.g. `WPC-95` (may be empty) |
+| `model.scoring`        | string      | Scoring type (may be empty)                     |
+| `model.flipper_count`  | int/null    | Number of flippers                              |
+| `model.ipdb_id`        | int/null    | Internet Pinball Database ID                    |
+| `model.pinside_rating` | float/null  | Pinside rating (0–10)                           |
 
 Machines are ordered alphabetically by model sort name (leading articles like "The" are stripped for sorting).
 
@@ -112,7 +126,14 @@ curl -H "Authorization: Bearer <key>" https://flipfix.example.com/api/v1/machine
     "model": {
       "name": "Medieval Madness",
       "manufacturer": "Williams",
-      "year": 1997
+      "year": 1997,
+      "month": 6,
+      "era": "SS",
+      "system": "WPC-95",
+      "scoring": "points",
+      "flipper_count": 2,
+      "ipdb_id": 4032,
+      "pinside_rating": 9.1
     }
   }
 }
@@ -129,3 +150,24 @@ The response fields are the same as the list endpoint — see the [field referen
 ## Versioning
 
 Endpoints are prefixed with `/api/v1/`. Breaking changes will use a new version prefix (`/api/v2/`, etc.).
+
+## Regenerating sample data from production
+
+The committed sample-data fixture (`docs/sample_data/records/machines.json`) is what
+`make sample-data` loads into local dev and CI databases. Maintainers can refresh it from the
+live collection using the machine list endpoint:
+
+```bash
+export SAMPLE_DATA_API_KEY=<a key from Django Admin → Core → API keys>
+python manage.py pull_sample_machines        # rewrites the fixture
+# or preview first:
+python manage.py pull_sample_machines --dry-run
+```
+
+Config: `--url` / `$SAMPLE_DATA_API_URL` (defaults to production) and `--api-key` /
+`$SAMPLE_DATA_API_KEY`. The command only reads the API and writes the file — it never touches
+the database, so dev/test stay fully offline. Fields the API does not expose (e.g.
+`acquisition_notes`, owner) are **not** regenerated, which keeps that data out of the public repo.
+
+Review the diff and commit the updated fixture; then `make sample-data` (on a fresh SQLite DB)
+loads it.

--- a/flipfix/apps/catalog/management/commands/pull_sample_machines.py
+++ b/flipfix/apps/catalog/management/commands/pull_sample_machines.py
@@ -90,9 +90,16 @@ class Command(BaseCommand):
                 timeout=REQUEST_TIMEOUT,
             )
             response.raise_for_status()
+            payload = response.json()
         except requests.RequestException as exc:
             raise CommandError(f"Failed to fetch {url}: {exc}") from exc
-        return response.json().get("machines", [])
+        except ValueError as exc:  # includes json.JSONDecodeError
+            raise CommandError(f"Invalid JSON from {url}: {exc}") from exc
+
+        machines = payload.get("machines") if isinstance(payload, dict) else None
+        if not isinstance(machines, list):
+            raise CommandError(f"Unexpected response from {url}: missing 'machines' list.")
+        return machines
 
     def _group(self, machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Regroup the API's flat instance list into the per-model fixture shape."""

--- a/flipfix/apps/catalog/management/commands/pull_sample_machines.py
+++ b/flipfix/apps/catalog/management/commands/pull_sample_machines.py
@@ -1,0 +1,139 @@
+"""Refresh the committed sample-data fixture from the production machine API.
+
+Maintainer tool: fetches ``/api/v1/machines/`` and rewrites
+``docs/sample_data/records/machines.json`` (the fixture that
+``create_sample_machines`` loads). It never touches the database and is
+deliberately *not* part of ``create_sample_data`` (which stays offline).
+
+Fields the API does not expose (e.g. ``acquisition_notes``, ``owner``) are not
+regenerated, by design — the API is the privacy boundary for the public repo.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import requests
+from decouple import config
+from django.core.management.base import BaseCommand, CommandError
+
+DEFAULT_URL = "https://flipfix.theflip.museum"
+DEFAULT_OUTPUT = Path("docs/sample_data/records/machines.json")
+REQUEST_TIMEOUT = 30
+
+# Model-level keys, in the order the fixture presents them.
+MODEL_FIELD_ORDER = (
+    "name",
+    "manufacturer",
+    "month",
+    "year",
+    "era",
+    "system",
+    "scoring",
+    "flipper_count",
+    "pinside_rating",
+    "ipdb_id",
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Fetch machines from the production API and rewrite the committed sample-data "
+        "fixture (docs/sample_data/records/machines.json). Maintainers only; requires an "
+        "API key (--api-key or $SAMPLE_DATA_API_KEY). Fields the API does not expose "
+        "(e.g. acquisition_notes) are not regenerated."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--url", help="API base URL (default: $SAMPLE_DATA_API_URL or production)."
+        )
+        parser.add_argument("--api-key", help="Bearer API key (default: $SAMPLE_DATA_API_KEY).")
+        parser.add_argument(
+            "--output",
+            type=Path,
+            default=DEFAULT_OUTPUT,
+            help=f"Fixture path to write (default: {DEFAULT_OUTPUT}).",
+        )
+        parser.add_argument(
+            "--dry-run", action="store_true", help="Summarize without writing the file."
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        base_url = (
+            options.get("url") or config("SAMPLE_DATA_API_URL", default=DEFAULT_URL)
+        ).rstrip("/")
+        api_key = options.get("api_key") or config("SAMPLE_DATA_API_KEY", default="")
+        if not api_key:
+            raise CommandError("No API key. Pass --api-key or set SAMPLE_DATA_API_KEY.")
+
+        machines = self._fetch(base_url, api_key)
+        models = self._group(machines)
+        self.stdout.write(f"Fetched {len(machines)} machines → {len(models)} models.")
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run: fixture not written."))
+            return
+
+        output: Path = options["output"]
+        output.write_text(json.dumps(models, indent=2, ensure_ascii=False) + "\n")
+        self.stdout.write(self.style.SUCCESS(f"Wrote {len(models)} models to {output}"))
+
+    def _fetch(self, base_url: str, api_key: str) -> list[dict[str, Any]]:
+        url = f"{base_url}/api/v1/machines/"
+        try:
+            response = requests.get(
+                url,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise CommandError(f"Failed to fetch {url}: {exc}") from exc
+        return response.json().get("machines", [])
+
+    def _group(self, machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Regroup the API's flat instance list into the per-model fixture shape."""
+        grouped: dict[Any, dict[str, Any]] = {}
+        for machine in machines:
+            model = machine.get("model", {})
+            # Group by IPDB id when present (stable), else fall back to the name.
+            key = (
+                ("ipdb", model["ipdb_id"]) if model.get("ipdb_id") else ("name", model.get("name"))
+            )
+            grouped.setdefault(key, {"model": model, "instances": []})["instances"].append(machine)
+
+        entries: list[dict[str, Any]] = []
+        for bucket in grouped.values():
+            model = bucket["model"]
+            entry = {
+                field: model[field]
+                for field in MODEL_FIELD_ORDER
+                if model.get(field) not in (None, "")
+            }
+            entry["instances"] = [
+                self._instance_entry(inst, model.get("name"))
+                for inst in sorted(bucket["instances"], key=lambda i: i.get("name") or "")
+            ]
+            entries.append(entry)
+
+        # Chronological, diff-friendly ordering matching the existing fixture.
+        entries.sort(key=lambda e: (e.get("year") or 0, e.get("name") or ""))
+        return entries
+
+    def _instance_entry(self, inst: dict[str, Any], model_name: str | None) -> dict[str, Any]:
+        entry: dict[str, Any] = {}
+        # Keep the instance name only when it differs from the model name, so
+        # single-instance models stay terse and multi-instance ones stay unique.
+        if inst.get("name") and inst["name"] != model_name:
+            entry["name"] = inst["name"]
+        if inst.get("short_name"):
+            entry["short_name"] = inst["short_name"]
+        if inst.get("serial_number"):
+            entry["serial_number"] = inst["serial_number"]
+        entry["operational_status"] = inst.get("operational_status")
+        if inst.get("location"):
+            entry["location"] = inst["location"]
+        return entry

--- a/flipfix/apps/catalog/management/commands/pull_sample_machines.py
+++ b/flipfix/apps/catalog/management/commands/pull_sample_machines.py
@@ -99,6 +99,10 @@ class Command(BaseCommand):
         machines = payload.get("machines") if isinstance(payload, dict) else None
         if not isinstance(machines, list):
             raise CommandError(f"Unexpected response from {url}: missing 'machines' list.")
+        # Validate each entry at the boundary so _group can trust the shape.
+        for entry in machines:
+            if not isinstance(entry, dict) or not isinstance(entry.get("model"), dict):
+                raise CommandError(f"Unexpected machine entry from {url}: {entry!r}")
         return machines
 
     def _group(self, machines: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/flipfix/apps/catalog/tests/test_pull_sample_machines.py
+++ b/flipfix/apps/catalog/tests/test_pull_sample_machines.py
@@ -1,0 +1,178 @@
+"""Tests for the pull_sample_machines management command."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import requests
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, tag
+
+from flipfix.apps.catalog.models import MachineInstance, MachineModel
+
+MODULE = "flipfix.apps.catalog.management.commands.pull_sample_machines"
+
+
+def _api_payload() -> dict:
+    """A fake /api/v1/machines/ response: two instances of one model, plus a sparse one."""
+    tz_model = {
+        "name": "Twilight Zone",
+        "manufacturer": "Bally",
+        "year": 1993,
+        "month": 9,
+        "era": "SS",
+        "system": "WPC",
+        "scoring": "points",
+        "flipper_count": 3,
+        "ipdb_id": 2684,
+        "pinside_rating": 8.9,
+    }
+    ballyhoo_model = {
+        "name": "Ballyhoo",
+        "manufacturer": "Bally",
+        "year": 1932,
+        "month": 1,
+        "era": "PM",
+        "system": "",
+        "scoring": "manual",
+        "flipper_count": 0,
+        "ipdb_id": 4817,
+        "pinside_rating": None,
+    }
+    return {
+        "machines": [
+            {
+                "asset_id": "M0001",
+                "name": "Twilight Zone",
+                "short_name": None,
+                "slug": "tz-1",
+                "serial_number": "111",
+                "operational_status": "good",
+                "location": "Floor",
+                "model": tz_model,
+            },
+            {
+                "asset_id": "M0002",
+                "name": "Twilight Zone 2",
+                "short_name": "TZ2",
+                "slug": "tz-2",
+                "serial_number": "222",
+                "operational_status": "fixing",
+                "location": "Workshop",
+                "model": tz_model,
+            },
+            {
+                "asset_id": "M0003",
+                "name": "Ballyhoo",
+                "short_name": None,
+                "slug": "ballyhoo",
+                "serial_number": "",
+                "operational_status": "good",
+                "location": None,
+                "model": ballyhoo_model,
+            },
+        ]
+    }
+
+
+def _mock_response(payload: dict) -> Mock:
+    response = Mock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+@tag("views")
+class PullSampleMachinesTests(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.output = Path(self._tmp) / "machines.json"
+        self.addCleanup(lambda: __import__("shutil").rmtree(self._tmp, ignore_errors=True))
+
+    def _run(self, **kwargs):
+        return call_command(
+            "pull_sample_machines",
+            "--api-key",
+            "test-key",
+            "--url",
+            "http://example.test",
+            "--output",
+            str(self.output),
+            **kwargs,
+        )
+
+    def test_groups_instances_into_fixture_shape(self):
+        with patch(
+            f"{MODULE}.requests.get", return_value=_mock_response(_api_payload())
+        ) as mock_get:
+            self._run()
+
+        # Hit the documented endpoint with a Bearer header.
+        url, kwargs = mock_get.call_args[0][0], mock_get.call_args[1]
+        self.assertEqual(url, "http://example.test/api/v1/machines/")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+
+        entries = json.loads(self.output.read_text())
+        self.assertEqual([e["name"] for e in entries], ["Ballyhoo", "Twilight Zone"])  # by year
+
+        ballyhoo, tz = entries
+        # Blank/null model fields are omitted.
+        self.assertNotIn("system", ballyhoo)
+        self.assertNotIn("pinside_rating", ballyhoo)
+        self.assertEqual(ballyhoo["era"], "PM")
+        self.assertEqual(len(ballyhoo["instances"]), 1)
+        bh_inst = ballyhoo["instances"][0]
+        self.assertNotIn("serial_number", bh_inst)  # was ""
+        self.assertNotIn("location", bh_inst)  # was null
+        self.assertEqual(bh_inst["operational_status"], "good")
+
+        # Twilight Zone keeps both instances; parity fields preserved.
+        self.assertEqual(tz["pinside_rating"], 8.9)
+        self.assertEqual(tz["ipdb_id"], 2684)
+        self.assertEqual(len(tz["instances"]), 2)
+        first, second = tz["instances"]
+        # Instance name omitted when equal to the model name...
+        self.assertNotIn("name", first)
+        self.assertEqual(first["serial_number"], "111")
+        self.assertEqual(first["location"], "Floor")
+        # ...and kept when it differs (with short_name).
+        self.assertEqual(second["name"], "Twilight Zone 2")
+        self.assertEqual(second["short_name"], "TZ2")
+
+    def test_dry_run_does_not_write(self):
+        with patch(f"{MODULE}.requests.get", return_value=_mock_response(_api_payload())):
+            self._run(dry_run=True)
+        self.assertFalse(self.output.exists())
+
+    def test_missing_api_key_raises(self):
+        # Force decouple to return defaults (no key configured).
+        with patch(f"{MODULE}.config", side_effect=lambda key, default=None: default):
+            with self.assertRaises(CommandError):
+                call_command("pull_sample_machines", "--output", str(self.output))
+
+    def test_http_error_raises_command_error(self):
+        with patch(f"{MODULE}.requests.get", side_effect=requests.ConnectionError("boom")):
+            with self.assertRaises(CommandError):
+                self._run()
+
+    def test_regenerated_fixture_is_importable(self):
+        """The written file round-trips through create_sample_machines."""
+        from flipfix.apps.catalog.management.commands.create_sample_machines import (
+            Command as CreateCommand,
+        )
+
+        with patch(f"{MODULE}.requests.get", return_value=_mock_response(_api_payload())):
+            self._run()
+
+        with patch.object(CreateCommand, "data_path", self.output):
+            call_command("create_sample_machines")
+
+        self.assertEqual(MachineModel.objects.count(), 2)
+        self.assertEqual(MachineInstance.objects.count(), 3)
+        # Grouping preserved: the two Twilight Zone instances share one model.
+        tz = MachineModel.objects.get(name="Twilight Zone")
+        self.assertEqual(tz.instances.count(), 2)

--- a/flipfix/apps/catalog/tests/test_pull_sample_machines.py
+++ b/flipfix/apps/catalog/tests/test_pull_sample_machines.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import secrets
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -91,13 +92,14 @@ class PullSampleMachinesTests(TestCase):
     def setUp(self):
         self._tmp = tempfile.mkdtemp()
         self.output = Path(self._tmp) / "machines.json"
+        self.api_key = secrets.token_hex(16)
         self.addCleanup(lambda: __import__("shutil").rmtree(self._tmp, ignore_errors=True))
 
     def _run(self, **kwargs):
         return call_command(
             "pull_sample_machines",
             "--api-key",
-            "test-key",
+            self.api_key,
             "--url",
             "http://example.test",
             "--output",
@@ -114,7 +116,7 @@ class PullSampleMachinesTests(TestCase):
         # Hit the documented endpoint with a Bearer header.
         url, kwargs = mock_get.call_args[0][0], mock_get.call_args[1]
         self.assertEqual(url, "http://example.test/api/v1/machines/")
-        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(kwargs["headers"]["Authorization"], f"Bearer {self.api_key}")
 
         entries = json.loads(self.output.read_text())
         self.assertEqual([e["name"] for e in entries], ["Ballyhoo", "Twilight Zone"])  # by year
@@ -156,6 +158,20 @@ class PullSampleMachinesTests(TestCase):
 
     def test_http_error_raises_command_error(self):
         with patch(f"{MODULE}.requests.get", side_effect=requests.ConnectionError("boom")):
+            with self.assertRaises(CommandError):
+                self._run()
+
+    def test_invalid_json_raises_command_error(self):
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.side_effect = ValueError("not JSON")
+        with patch(f"{MODULE}.requests.get", return_value=response):
+            with self.assertRaises(CommandError):
+                self._run()
+
+    def test_unexpected_shape_raises_command_error(self):
+        # A 200 with the wrong shape (e.g. an HTML error page parsed as a list).
+        with patch(f"{MODULE}.requests.get", return_value=_mock_response(["not", "a", "dict"])):
             with self.assertRaises(CommandError):
                 self._run()
 

--- a/flipfix/apps/catalog/tests/test_pull_sample_machines.py
+++ b/flipfix/apps/catalog/tests/test_pull_sample_machines.py
@@ -6,11 +6,13 @@ import json
 import secrets
 import tempfile
 from pathlib import Path
+from unittest import skipUnless
 from unittest.mock import Mock, patch
 
 import requests
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import connection
 from django.test import TestCase, tag
 
 from flipfix.apps.catalog.models import MachineInstance, MachineModel
@@ -175,8 +177,12 @@ class PullSampleMachinesTests(TestCase):
             with self.assertRaises(CommandError):
                 self._run()
 
+    @skipUnless(
+        connection.vendor == "sqlite",
+        "create_sample_machines is SQLite-only (CI runs on PostgreSQL)",
+    )
     def test_regenerated_fixture_is_importable(self):
-        """The written file round-trips through create_sample_machines."""
+        """The written file round-trips through create_sample_machines (SQLite only)."""
         from flipfix.apps.catalog.management.commands.create_sample_machines import (
             Command as CreateCommand,
         )

--- a/flipfix/apps/catalog/tests/test_pull_sample_machines.py
+++ b/flipfix/apps/catalog/tests/test_pull_sample_machines.py
@@ -177,6 +177,13 @@ class PullSampleMachinesTests(TestCase):
             with self.assertRaises(CommandError):
                 self._run()
 
+    def test_malformed_machine_entry_raises_command_error(self):
+        # 'machines' is a list, but an entry isn't a dict with a dict 'model'.
+        payload = {"machines": [{"name": "Broken", "model": "not-a-dict"}]}
+        with patch(f"{MODULE}.requests.get", return_value=_mock_response(payload)):
+            with self.assertRaises(CommandError):
+                self._run()
+
     @skipUnless(
         connection.vendor == "sqlite",
         "create_sample_machines is SQLite-only (CI runs on PostgreSQL)",

--- a/flipfix/apps/core/tests/test_machine_api.py
+++ b/flipfix/apps/core/tests/test_machine_api.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import secrets
+from decimal import Decimal
 
 from django.db import IntegrityError
 from django.test import TestCase, tag
 
-from flipfix.apps.catalog.models import Location
+from flipfix.apps.catalog.models import Location, MachineModel
 from flipfix.apps.core.models import ApiKey
 from flipfix.apps.core.test_utils import create_machine, create_machine_model
 
@@ -110,6 +111,42 @@ class MachineListApiResponseTests(TestCase):
         self.assertEqual(m["model"]["name"], "Medieval Madness")
         self.assertEqual(m["model"]["manufacturer"], "Williams")
         self.assertEqual(m["model"]["year"], 1997)
+
+    def test_model_exposes_parity_fields(self):
+        """The serialized model includes the catalog metadata sample data needs."""
+        model = create_machine_model(
+            name="Twilight Zone",
+            manufacturer="Bally",
+            year=1993,
+            month=9,
+            era=MachineModel.Era.SS,
+            system="WPC",
+            scoring="points",
+            flipper_count=3,
+            ipdb_id=2684,
+            pinside_rating=Decimal("8.90"),
+        )
+        create_machine(model=model, name="Twilight Zone")
+
+        m = self._get().json()["machines"][0]["model"]
+        self.assertEqual(m["month"], 9)
+        self.assertEqual(m["era"], "SS")
+        self.assertEqual(m["system"], "WPC")
+        self.assertEqual(m["scoring"], "points")
+        self.assertEqual(m["flipper_count"], 3)
+        self.assertEqual(m["ipdb_id"], 2684)
+        # Emitted as a JSON number, not a Decimal-as-string.
+        self.assertEqual(m["pinside_rating"], 8.9)
+        self.assertIsInstance(m["pinside_rating"], float)
+
+    def test_null_model_fields_serialize_as_null(self):
+        """Absent optional model fields serialize as null (not omitted)."""
+        model = create_machine_model(pinside_rating=None, ipdb_id=None)
+        create_machine(model=model, name="No Metadata")
+
+        m = self._get().json()["machines"][0]["model"]
+        self.assertIsNone(m["pinside_rating"])
+        self.assertIsNone(m["ipdb_id"])
 
     def test_null_location(self):
         """Machine with no location returns null for location field."""

--- a/flipfix/apps/core/views/api.py
+++ b/flipfix/apps/core/views/api.py
@@ -25,6 +25,15 @@ def _serialize_machine(m: MachineInstance) -> dict:
             "name": m.model.name,
             "manufacturer": m.model.manufacturer,
             "year": m.model.year,
+            "month": m.model.month,
+            "era": m.model.era,
+            "system": m.model.system,
+            "scoring": m.model.scoring,
+            "flipper_count": m.model.flipper_count,
+            "ipdb_id": m.model.ipdb_id,
+            "pinside_rating": (
+                float(m.model.pinside_rating) if m.model.pinside_rating is not None else None
+            ),
         },
     }
 


### PR DESCRIPTION
## Summary

Enables refreshing local **dev/test sample data from production**, the follow-up noted in #346.

The committed fixture `docs/sample_data/records/machines.json` (loaded by `make sample-data`) is richer than the read-only API exposed, so production data couldn't be pulled down complete. This PR closes that gap and adds the pull tool.

## Changes

**1. Extend the machine API** (`flipfix/apps/core/views/api.py`)
Add to the serialized `model{}`: `era, month, system, scoring, flipper_count, ipdb_id, pinside_rating` (emitted as a JSON number, not a `Decimal` string). These mirror exactly what the fixture uses. No schema/migration changes.

**2. New `pull_sample_machines` management command** (`flipfix/apps/catalog/management/commands/`)
A maintainer tool that:
- fetches `/api/v1/machines/` with a Bearer key — config via `--api-key`/`$SAMPLE_DATA_API_KEY` and `--url`/`$SAMPLE_DATA_API_URL` (defaults to prod), plus `--output` and `--dry-run`;
- regroups the API's flat instance list back into the fixture's per-model shape (keyed by `ipdb_id`/name, blanks omitted, instance `name` kept only when it differs from the model name, stable chronological ordering);
- rewrites the committed fixture.

It **never touches the database** and is deliberately **not** part of `create_sample_data`, so dev/test stay fully offline and reproducible. Fields the API doesn't expose (`acquisition_notes`, owner) are not regenerated — keeping them out of the public repo.

**3. Tests, docs, config**
- New API tests for the added fields (incl. `pinside_rating` as a number); command tests with mocked HTTP covering grouping, blank-field omission, instance-name handling, missing-key/HTTP error paths, and a **round-trip** through `create_sample_machines`.
- `docs/API.md` field table + examples + a "Regenerating sample data" section; `.env.example` block; `make pull-sample-machines` target.

## Workflow it enables

```bash
export SAMPLE_DATA_API_KEY=<key from Django Admin → Core → API keys>
python manage.py pull_sample_machines --dry-run   # preview
python manage.py pull_sample_machines             # rewrite fixture; review diff & commit
make sample-data                                  # load into a fresh dev DB
```

## Testing

- `make test` for catalog + core: 625 passing (includes the new API + command tests).
- `make quality` clean (ruff, djlint, mypy across 383 files).
- Live pull not exercised in CI (needs a real key + network); documented as a manual maintainer step.

Note: this PR does **not** include a regenerated `machines.json` — that's a separate, credential-gated step the maintainer runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add command to refresh committed sample machine data from production
  * API responses now include additional machine model metadata (era, system, scoring, flipper count, IPDB ID, pinside rating)

* **Documentation**
  * Expanded machine API schema and examples
  * Added guide for regenerating sample data from production (usage, dry-run, env vars)

* **Tests**
  * Added test suite covering regeneration, shaping rules, error cases, and import round-trip

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipfix/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->