### PR TITLE
feat(catalog): list excluded machines on Explore + infer era from year

### DIFF
--- a/flipfix/apps/catalog/models.py
+++ b/flipfix/apps/catalog/models.py
@@ -154,6 +154,27 @@ class MachineModel(TimeStampedMixin):
     def __str__(self) -> str:
         return self.name
 
+    @staticmethod
+    def era_for_year(year: int | None) -> str:
+        """Infer a technology era from a manufacture year.
+
+        A fallback for when ``era`` is blank: pinball moved from pure-mechanical
+        to electromechanical around 1935, and to solid-state in 1977. Returns
+        "" when the year is unknown (nothing to infer from).
+        """
+        if year is None:
+            return ""
+        if year <= 1934:
+            return MachineModel.Era.PM
+        if year <= 1976:
+            return MachineModel.Era.EM
+        return MachineModel.Era.SS
+
+    @property
+    def effective_era(self) -> str:
+        """Stored era, or one inferred from the year when era is blank."""
+        return self.era or MachineModel.era_for_year(self.year)
+
     def get_admin_history_url(self) -> str:
         """Return URL to this model's Django admin change history."""
         return reverse("admin:catalog_machinemodel_history", args=[self.pk])

--- a/flipfix/apps/catalog/tests/test_explore_view.py
+++ b/flipfix/apps/catalog/tests/test_explore_view.py
@@ -76,18 +76,63 @@ class MachineExploreViewDataTests(TestCase):
         self.assertEqual(dot["status_label"], "Broken")
         self.assertEqual(dot["url"], reverse("maintainer-machine-detail", args=["kiss"]))
 
-    def test_excludes_instances_missing_chart_dimensions(self):
-        """Instances whose model lacks year, manufacturer or era are not charted."""
+    def test_excludes_instances_missing_year_or_manufacturer(self):
+        """Machines missing year or manufacturer are not charted (era is inferable)."""
         create_machine(
             model=create_machine_model(manufacturer="Gottlieb", year=1975, era=MachineModel.Era.EM)
         )
         create_machine(model=create_machine_model(year=None), slug="no-year")
         create_machine(model=create_machine_model(manufacturer=""), slug="no-mfr")
-        create_machine(model=create_machine_model(era=""), slug="no-era")
+        # Blank era but a known year is now inferred (plotted), not excluded.
+        create_machine(model=create_machine_model(year=2001, era=""), slug="no-era")
 
         context = self._chart()
+        self.assertEqual(len(context["chart_data"]), 2)  # Gottlieb + inferred-era machine
+        self.assertEqual(context["excluded_count"], 2)  # no-year, no-mfr
+        self.assertEqual(len(context["excluded"]), 2)
+
+    def test_excluded_entries_name_the_missing_dimensions(self):
+        """Each excluded entry links to the machine and lists what it's missing."""
+        create_machine(
+            model=create_machine_model(name="No Year", year=None, era=MachineModel.Era.SS),
+            name="No Year",
+            slug="no-year",
+        )
+        create_machine(
+            model=create_machine_model(name="Bare", year=None, manufacturer="", era=""),
+            name="Bare",
+            slug="bare",
+        )
+
+        excluded = {m["name"]: m for m in self._chart()["excluded"]}
+        self.assertEqual(excluded["No Year"]["missing"], ["year"])
+        self.assertEqual(excluded["Bare"]["missing"], ["year", "manufacturer", "era"])
+        self.assertEqual(
+            excluded["No Year"]["url"], reverse("maintainer-machine-detail", args=["no-year"])
+        )
+
+    def test_missing_era_is_inferred_from_year(self):
+        """A machine with year + manufacturer but no era is plotted via inferred era."""
+        create_machine(
+            model=create_machine_model(manufacturer="Gottlieb", year=1965, era=""),
+            name="Eraless EM",
+            slug="eraless",
+        )
+
+        context = self._chart()
+        self.assertEqual(context["excluded"], [])
         self.assertEqual(len(context["chart_data"]), 1)
-        self.assertEqual(context["excluded_count"], 3)
+        dot = context["chart_data"][0]
+        self.assertEqual(dot["era"], MachineModel.Era.EM)
+        self.assertEqual(dot["era_label"], "Electromechanical")
+
+    def test_no_excluded_when_all_plottable(self):
+        create_machine(
+            model=create_machine_model(manufacturer="Bally", year=1980, era=MachineModel.Era.EM)
+        )
+        context = self._chart()
+        self.assertEqual(context["excluded"], [])
+        self.assertEqual(context["excluded_count"], 0)
 
     def test_legend_lists_all_eras(self):
         legend = self._chart()["legend"]

--- a/flipfix/apps/catalog/tests/test_machine_models.py
+++ b/flipfix/apps/catalog/tests/test_machine_models.py
@@ -58,6 +58,37 @@ class MachineModelSortNameTests(TestCase):
 
 
 @tag("models")
+class MachineModelEraTests(TestCase):
+    """Era inference from manufacture year."""
+
+    def test_era_for_year_boundaries(self):
+        cases = {
+            None: "",
+            1930: MachineModel.Era.PM,
+            1934: MachineModel.Era.PM,  # last PM year
+            1935: MachineModel.Era.EM,  # first EM year
+            1976: MachineModel.Era.EM,  # last EM year
+            1977: MachineModel.Era.SS,  # first SS year
+            2024: MachineModel.Era.SS,
+        }
+        for year, expected in cases.items():
+            self.assertEqual(MachineModel.era_for_year(year), expected, f"year={year}")
+
+    def test_effective_era_prefers_stored_value(self):
+        # A 1990 machine explicitly tagged PM keeps PM (no override by inference).
+        model = MachineModel(name="Oddball", year=1990, era=MachineModel.Era.PM)
+        self.assertEqual(model.effective_era, MachineModel.Era.PM)
+
+    def test_effective_era_infers_when_blank(self):
+        model = MachineModel(name="Untagged", year=1965, era="")
+        self.assertEqual(model.effective_era, MachineModel.Era.EM)
+
+    def test_effective_era_blank_when_no_era_and_no_year(self):
+        model = MachineModel(name="Mystery", year=None, era="")
+        self.assertEqual(model.effective_era, "")
+
+
+@tag("models")
 class MachineInstanceModelTests(TestCase):
     """Tests for the MachineInstance model."""
 

--- a/flipfix/apps/catalog/views/explore.py
+++ b/flipfix/apps/catalog/views/explore.py
@@ -24,39 +24,67 @@ class MachineExploreView(TemplateView):
 
     template_name = "catalog/explore.html"
 
+    @staticmethod
+    def _missing_dimensions(model: MachineModel) -> list[str]:
+        """Return the chart dimensions a model is missing (empty if plottable)."""
+        missing = []
+        if model.year is None:
+            missing.append("year")
+        if not model.manufacturer:
+            missing.append("manufacturer")
+        # era can be inferred from the year, so it's only "missing" when neither
+        # a stored era nor a year is available.
+        if not model.effective_era:
+            missing.append("era")
+        return missing
+
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
 
-        # Only machines whose model carries all three chart dimensions can be
-        # plotted. ``visible()`` select_related's the model, so reading
-        # model fields and ``get_*_display()`` below adds no extra queries.
-        owned = MachineInstance.objects.visible()
-        instances = (
-            owned.filter(model__year__isnull=False)
-            .exclude(model__manufacturer="")
-            .exclude(model__era="")
-            .order_by("model__manufacturer", "model__year", "model__sort_name")
+        # Partition every owned machine in a single pass: those whose model
+        # carries all three chart dimensions are plotted; the rest are listed
+        # (with the reason) so a maintainer can find and fix the missing data.
+        # ``visible()`` select_related's the model, so reading model fields and
+        # ``get_*_display()`` below adds no extra queries.
+        owned = MachineInstance.objects.visible().order_by(
+            "model__manufacturer", "model__year", "model__sort_name"
         )
 
-        chart_data = [
-            {
-                "name": instance.short_display_name,
-                "manufacturer": instance.model.manufacturer,
-                "year": instance.model.year,
-                "era": instance.model.era,
-                "era_label": instance.model.get_era_display(),
-                "status": instance.operational_status,
-                "status_label": instance.get_operational_status_display(),
-                "url": reverse("maintainer-machine-detail", args=[instance.slug]),
-            }
-            for instance in instances
-        ]
+        chart_data = []
+        excluded = []
+        for instance in owned:
+            model = instance.model
+            missing = self._missing_dimensions(model)
+            if missing:
+                excluded.append(
+                    {
+                        "name": instance.short_display_name,
+                        "url": reverse("maintainer-machine-detail", args=[instance.slug]),
+                        "missing": missing,
+                    }
+                )
+                continue
+            era = model.effective_era
+            chart_data.append(
+                {
+                    "name": instance.short_display_name,
+                    "manufacturer": model.manufacturer,
+                    "year": model.year,
+                    "era": era,
+                    "era_label": MachineModel.Era(era).label,
+                    "status": instance.operational_status,
+                    "status_label": instance.get_operational_status_display(),
+                    "url": reverse("maintainer-machine-detail", args=[instance.slug]),
+                }
+            )
+
+        # Excluded machines often lack manufacturer/year, so sort by name.
+        excluded.sort(key=lambda m: m["name"].lower())
 
         context["chart_data"] = chart_data
         context["legend"] = [{"era": era.value, "label": era.label} for era in MachineModel.Era]
-        # Count exclusions against the same base queryset chart_data is built
-        # from, so the two stay consistent (chart_data is always a subset).
-        context["excluded_count"] = owned.count() - len(chart_data)
+        context["excluded"] = excluded
+        context["excluded_count"] = len(excluded)
         context["meta_description"] = (
             "Explore The Flip's pinball collection by year, manufacturer and technology era."
         )

--- a/flipfix/static/core/styles.css
+++ b/flipfix/static/core/styles.css
@@ -3520,6 +3520,23 @@ a.stat:focus-visible {
   font-size: var(--text-sm);
 }
 
+/* Disclosure listing machines excluded from the chart (missing data) */
+.machine-chart__excluded {
+  margin-top: var(--space-3);
+}
+
+.machine-chart__excluded > summary {
+  margin-top: 0;
+  cursor: pointer;
+}
+
+.machine-chart__excluded-list {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-5);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+}
+
 /* No-JS fallback table (JS demotes it to .visually-hidden once the SVG renders) */
 .machine-chart__table {
   width: 100%;

--- a/templates/catalog/explore.html
+++ b/templates/catalog/explore.html
@@ -24,10 +24,20 @@
   <!-- CHART: rendered into the mount point by catalog_chart.js -->
   <div class="machine-chart" id="machine-chart" data-machine-chart></div>
   {{ chart_data|json_script:"machine-chart-data" }}
-  {% if excluded_count %}
-    <p class="machine-chart__note text-muted">
-      {{ excluded_count }} machine{{ excluded_count|pluralize }} not shown (missing year, manufacturer or era).
-    </p>
+  {% if excluded %}
+    <details class="machine-chart__excluded">
+      <summary class="machine-chart__note text-muted">
+        {{ excluded_count }} machine{{ excluded_count|pluralize }} not shown (missing year, manufacturer or era)
+      </summary>
+      <ul class="machine-chart__excluded-list">
+        {% for machine in excluded %}
+          <li>
+            <a href="{{ machine.url }}">{{ machine.name }}</a>
+            <span class="text-muted">— missing {{ machine.missing|join:", " }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </details>
   {% endif %}
   <!-- Accessible / no-JS fallback: visible by default; catalog_chart.js hides it
        (visually-hidden) once the SVG renders, so it stays available to screen


### PR DESCRIPTION
## Summary

Two improvements to how the **Explore** chart handles machines with incomplete catalog data.

### 1. The "N machines not shown" note is now actionable
Previously it was just a count. It's now an expandable `<details>` disclosure that lists each excluded machine, **linked to its page**, with the specific missing dimensions:

> **Eight Ball** — missing year, era

Chosen over a hover tooltip (invisible on mobile/keyboard) or an HTML comment (source-only) — a disclosure is discoverable, accessible, needs no JS, and lets a maintainer jump straight to fixing the gap. The view now partitions owned machines in a single pass into plotted vs. excluded (with reasons).

### 2. Missing `era` is inferred from `year`
New `MachineModel.era_for_year()` / `effective_era`: when `era` is blank, infer it from the year — **≤1934 → PM, 1935–1976 → EM, 1977+ → SS**. The chart plots via `effective_era`, so a machine with a year + manufacturer but no era is now **shown with its inferred era** instead of dropped.

`year` and `manufacturer` can't be inferred, so machines missing those still appear in the not-shown list.

## Deliberately out of scope
The **API serializer is unchanged** — it still returns the *stored* `era` (blank if unset), not the inferred one. This keeps `pull_sample_machines` from writing guessed eras into the sample-data fixture as if they were real.

## Notes / possible follow-ups
- **Inferred-era dots are visually identical to known-era ones.** That's the simplest reading of "add a default"; happy to mark inferred dots (lighter fill, or an "(inferred)" hint in the hover card) if you'd prefer the distinction visible.
- Excluded machine names/links are shown on this public page — consistent with the existing public machines list and machine-detail route.

## Testing
- New: `era_for_year` boundary tests (1934/1935/1976/1977/None), `effective_era` precedence + inference, a chart test that a blank-era + known-year machine plots as the inferred era, and excluded-list content/reason tests.
- Updated the old exclusion test (the blank-era-with-year case is now plotted, not excluded).
- 58 catalog tests pass; `make quality` clean (ruff, djlint, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine technology era is now automatically inferred from the machine's year when not explicitly set, allowing more machines to be included in explore charts.
  * Excluded machines list is now expandable, displaying specific missing data dimensions for each machine.

* **Style**
  * Improved styling and presentation for the excluded machines disclosure section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipfix/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->