### PR TITLE
feat(api): append log entries to problem reports via write API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -221,6 +221,61 @@ When `mark_broken` is `true`, the status change is written through the machine's
 changed → Broken" log entry is recorded automatically). Closing the report does **not** revert the
 machine to `good` — that's left to a maintainer.
 
+### `POST /api/v1/problem-reports/<pk>/log-entries/`
+
+**Write endpoint** — requires a key with the **write** capability (see [Read vs. write
+keys](#read-vs-write-keys)).
+
+Appends a log entry to an existing problem report. This is the companion to the idempotent
+problem-report create above: when a recurrence (e.g. juice shutting an already-broken machine down
+_again_) hits the `200` idempotent path and creates no new report, the caller uses the returned
+`problem_report.id` here to record what happened.
+
+**Request body:**
+
+| Field              | Type   | Default        | Description                                       |
+| ------------------ | ------ | -------------- | ------------------------------------------------- |
+| `text`             | string | **required**   | The log entry body (must be non-empty)            |
+| `occurred_at`      | string | now            | ISO-8601 datetime of when the work/event occurred |
+| `reported_by_name` | string | key `app_name` | Display name for the author (max 120 chars)       |
+
+`reported_by_name` is stored as the entry's `maintainer_names`. When omitted, it defaults to the API
+key's `app_name`, so an entry always carries attribution.
+
+**Example request:**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <write-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "text": "Auto power-off recurrence: 182W peak vs 49W baseline over 3m12s",
+        "reported_by_name": "Juice"
+      }' \
+  https://flipfix.example.com/api/v1/problem-reports/42/log-entries/
+```
+
+**Example response (`201 Created`):**
+
+```json
+{
+  "log_entry": {
+    "id": 7,
+    "problem_report_id": 42,
+    "machine_asset_id": "M0001",
+    "text": "Auto power-off recurrence: 182W peak vs 49W baseline over 3m12s",
+    "maintainer_names": "Juice",
+    "occurred_at": "2026-06-19T15:51:00+00:00",
+    "created_at": "2026-06-19T15:51:00+00:00"
+  }
+}
+```
+
+Returns `404` if no problem report has the given `pk`, and `400` for a missing/empty `text`, an
+unparseable `occurred_at`, malformed JSON, or a `reported_by_name` longer than 120 characters. The
+log entry is linked to the report's machine, so it appears on both the report and the machine
+timeline (and posts to the Discord #logs channel like any other log entry).
+
 ## Versioning
 
 Endpoints are prefixed with `/api/v1/`. Breaking changes will use a new version prefix (`/api/v2/`, etc.).

--- a/flipfix/apps/core/tests/test_log_entry_api.py
+++ b/flipfix/apps/core/tests/test_log_entry_api.py
@@ -127,6 +127,13 @@ class LogEntryCreateApiBehaviorTests(TestCase):
     def test_invalid_occurred_at_returns_400(self):
         response = self._post({"text": "x", "occurred_at": "not-a-date"})
         self.assertEqual(response.status_code, 400)
+        self.assertFalse(LogEntry.objects.exists())
+
+    def test_non_string_occurred_at_returns_400(self):
+        """A non-string occurred_at is a 400, not a 500 (parse_datetime TypeError)."""
+        response = self._post({"text": "x", "occurred_at": 123})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(LogEntry.objects.exists())
 
     def test_overlong_reported_by_name_returns_400(self):
         response = self._post({"text": "x", "reported_by_name": "z" * 121})
@@ -141,3 +148,4 @@ class LogEntryCreateApiBehaviorTests(TestCase):
             HTTP_AUTHORIZATION=self.auth,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertFalse(LogEntry.objects.exists())

--- a/flipfix/apps/core/tests/test_log_entry_api.py
+++ b/flipfix/apps/core/tests/test_log_entry_api.py
@@ -1,0 +1,143 @@
+"""Tests for the write log-entry API (POST /api/v1/problem-reports/<pk>/log-entries/)."""
+
+from __future__ import annotations
+
+import json
+import secrets
+
+from django.test import TestCase, tag
+
+from flipfix.apps.core.models import ApiKey
+from flipfix.apps.core.test_utils import create_machine
+from flipfix.apps.maintenance.models import LogEntry, ProblemReport
+
+
+@tag("views")
+class LogEntryCreateApiAuthTests(TestCase):
+    """Authentication and write-scope tests for the create endpoint."""
+
+    def setUp(self):
+        self.machine = create_machine(name="Test Machine")
+        self.report = ProblemReport.objects.create(
+            machine=self.machine, priority=ProblemReport.Priority.UNPLAYABLE
+        )
+        self.url = f"/api/v1/problem-reports/{self.report.pk}/log-entries/"
+
+    def _post(self, auth: str | None, body: dict | None = None):
+        data = json.dumps(body or {"text": "x"})
+        if auth is None:
+            return self.client.post(self.url, data=data, content_type="application/json")
+        return self.client.post(
+            self.url, data=data, content_type="application/json", HTTP_AUTHORIZATION=auth
+        )
+
+    def test_no_auth_header_returns_401(self):
+        response = self._post(None)
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(response.json()["success"])
+
+    def test_invalid_key_returns_403(self):
+        response = self._post(f"Bearer {secrets.token_hex(32)}")
+        self.assertEqual(response.status_code, 403)
+
+    def test_read_only_key_returns_403(self):
+        """A key without can_write cannot use the write endpoint."""
+        key = ApiKey.objects.create(app_name="signage", can_write=False)
+        response = self._post(f"Bearer {key.key}")
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(LogEntry.objects.exists())
+
+    def test_unknown_report_returns_404(self):
+        key = ApiKey.objects.create(app_name="juice", can_write=True)
+        response = self.client.post(
+            "/api/v1/problem-reports/999999/log-entries/",
+            data=json.dumps({"text": "x"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {key.key}",
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(LogEntry.objects.exists())
+
+
+@tag("views")
+class LogEntryCreateApiBehaviorTests(TestCase):
+    """Behavior tests for the create endpoint with a write-capable key."""
+
+    def setUp(self):
+        self.machine = create_machine(name="Test Machine")
+        self.report = ProblemReport.objects.create(
+            machine=self.machine, priority=ProblemReport.Priority.UNPLAYABLE
+        )
+        self.url = f"/api/v1/problem-reports/{self.report.pk}/log-entries/"
+        self.key = ApiKey.objects.create(app_name="juice", can_write=True)
+        self.auth = f"Bearer {self.key.key}"
+
+    def _post(self, body: dict):
+        return self.client.post(
+            self.url,
+            data=json.dumps(body),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.auth,
+        )
+
+    def test_creates_log_entry(self):
+        response = self._post(
+            {
+                "text": "Auto power-off recurrence: 182W peak vs 49W baseline over 3m12s",
+                "reported_by_name": "Juice",
+            }
+        )
+        self.assertEqual(response.status_code, 201)
+        entry = LogEntry.objects.get()
+        self.assertEqual(entry.problem_report, self.report)
+        self.assertEqual(entry.machine, self.machine)
+        self.assertEqual(
+            entry.text, "Auto power-off recurrence: 182W peak vs 49W baseline over 3m12s"
+        )
+        self.assertEqual(entry.maintainer_names, "Juice")
+
+        data = response.json()["log_entry"]
+        self.assertEqual(data["id"], entry.pk)
+        self.assertEqual(data["problem_report_id"], self.report.pk)
+        self.assertEqual(data["machine_asset_id"], self.machine.asset_id)
+
+    def test_reported_by_name_falls_back_to_app_name(self):
+        """Without reported_by_name, attribution defaults to the API key's app_name."""
+        response = self._post({"text": "shut down again"})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(LogEntry.objects.get().maintainer_names, "juice")
+
+    def test_occurred_at_override(self):
+        response = self._post({"text": "x", "occurred_at": "2026-01-02T03:04:05+00:00"})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            LogEntry.objects.get().occurred_at.isoformat(), "2026-01-02T03:04:05+00:00"
+        )
+
+    def test_missing_text_returns_400(self):
+        response = self._post({"reported_by_name": "Juice"})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(LogEntry.objects.exists())
+
+    def test_blank_text_returns_400(self):
+        response = self._post({"text": "   "})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(LogEntry.objects.exists())
+
+    def test_invalid_occurred_at_returns_400(self):
+        response = self._post({"text": "x", "occurred_at": "not-a-date"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_overlong_reported_by_name_returns_400(self):
+        response = self._post({"text": "x", "reported_by_name": "z" * 121})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(LogEntry.objects.exists())
+
+    def test_malformed_json_returns_400(self):
+        response = self.client.post(
+            self.url,
+            data="{not json",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.auth,
+        )
+        self.assertEqual(response.status_code, 400)

--- a/flipfix/apps/core/tests/test_problem_report_api.py
+++ b/flipfix/apps/core/tests/test_problem_report_api.py
@@ -150,6 +150,13 @@ class ProblemReportCreateApiBehaviorTests(TestCase):
     def test_invalid_occurred_at_returns_400(self):
         response = self._post({"priority": "minor", "occurred_at": "not-a-date"})
         self.assertEqual(response.status_code, 400)
+        self.assertFalse(ProblemReport.objects.exists())
+
+    def test_non_string_occurred_at_returns_400(self):
+        """A non-string occurred_at is a 400, not a 500 (parse_datetime TypeError)."""
+        response = self._post({"priority": "minor", "occurred_at": 123})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(ProblemReport.objects.exists())
 
     def test_malformed_json_returns_400(self):
         response = self.client.post(

--- a/flipfix/apps/core/views/api.py
+++ b/flipfix/apps/core/views/api.py
@@ -15,7 +15,37 @@ from django.views.decorators.csrf import csrf_exempt
 
 from flipfix.apps.catalog.models import MachineInstance
 from flipfix.apps.core.api_auth import json_api_view, validate_api_key
-from flipfix.apps.maintenance.models import ProblemReport
+from flipfix.apps.maintenance.models import LogEntry, ProblemReport
+
+
+def _load_json_body(request) -> dict:
+    """Parse a request body as a JSON object.
+
+    Raises ``ValidationError`` (rendered as 400) on malformed or non-object input.
+    """
+    try:
+        body = json.loads(request.body or b"{}")
+    except json.JSONDecodeError as e:
+        raise ValidationError("Request body must be valid JSON") from e
+    if not isinstance(body, dict):
+        raise ValidationError("Request body must be a JSON object")
+    return body
+
+
+def _parse_occurred_at(raw):
+    """Parse an optional ISO-8601 ``occurred_at`` value, defaulting to now.
+
+    Naive datetimes are made timezone-aware.  Raises ``ValidationError``
+    (rendered as 400) when a value is given but cannot be parsed.
+    """
+    if not raw:
+        return timezone.now()
+    occurred_at = parse_datetime(raw)
+    if occurred_at is None:
+        raise ValidationError("Invalid occurred_at: expected an ISO-8601 datetime")
+    if timezone.is_naive(occurred_at):
+        occurred_at = timezone.make_aware(occurred_at)
+    return occurred_at
 
 
 def _serialize_machine(m: MachineInstance) -> dict:
@@ -154,12 +184,7 @@ class MachineProblemReportCreateApiView(View):
 
         Raises ``ValidationError`` (rendered as 400) on malformed input.
         """
-        try:
-            body = json.loads(request.body or b"{}")
-        except json.JSONDecodeError as e:
-            raise ValidationError("Request body must be valid JSON") from e
-        if not isinstance(body, dict):
-            raise ValidationError("Request body must be a JSON object")
+        body = _load_json_body(request)
 
         priority = body.get("priority", ProblemReport.Priority.MINOR)
         if priority not in ProblemReport.Priority.values:
@@ -169,21 +194,71 @@ class MachineProblemReportCreateApiView(View):
         if problem_type not in ProblemReport.ProblemType.values:
             raise ValidationError(f"Invalid problem_type: {problem_type!r}")
 
-        occurred_at_raw = body.get("occurred_at")
-        if occurred_at_raw:
-            occurred_at = parse_datetime(occurred_at_raw)
-            if occurred_at is None:
-                raise ValidationError("Invalid occurred_at: expected an ISO-8601 datetime")
-            if timezone.is_naive(occurred_at):
-                occurred_at = timezone.make_aware(occurred_at)
-        else:
-            occurred_at = timezone.now()
-
         return {
             "priority": priority,
             "problem_type": problem_type,
             "description": body.get("description", ""),
             "reported_by_name": body.get("reported_by_name", ""),
-            "occurred_at": occurred_at,
+            "occurred_at": _parse_occurred_at(body.get("occurred_at")),
             "mark_broken": bool(body.get("mark_broken", False)),
         }
+
+
+def _serialize_log_entry(entry: LogEntry) -> dict:
+    """Serialize a LogEntry to a dict for JSON responses."""
+    return {
+        "id": entry.pk,
+        "problem_report_id": entry.problem_report_id,
+        "machine_asset_id": entry.machine.asset_id,
+        "text": entry.text,
+        "maintainer_names": entry.maintainer_names,
+        "occurred_at": entry.occurred_at.isoformat(),
+        "created_at": entry.created_at.isoformat(),
+    }
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class ProblemReportLogEntryCreateApiView(View):
+    """Write API: append a log entry to an existing problem report.
+
+    Requires an API key with ``can_write`` enabled.  Lets services such as
+    juice record a *recurrence* (e.g. shutting an already-broken machine down
+    again) on a report that the idempotent problem-report endpoint returned
+    without creating anything new.
+    """
+
+    @json_api_view
+    def post(self, request, pk: int):
+        api_key = validate_api_key(request, require_write=True)
+
+        try:
+            report = ProblemReport.objects.select_related("machine").get(pk=pk)
+        except ProblemReport.DoesNotExist as e:
+            raise Http404(f"Problem report with ID '{pk}' not found") from e
+
+        body = _load_json_body(request)
+
+        text = str(body.get("text", "")).strip()
+        if not text:
+            raise ValidationError("text is required")
+
+        # reported_by_name maps to LogEntry.maintainer_names.  Fall back to the
+        # key's app_name so the model's "a maintainer or a name is required"
+        # invariant holds and the entry always carries attribution.
+        maintainer_names = str(body.get("reported_by_name", "")).strip() or api_key.app_name
+        max_name_length = LogEntry._meta.get_field("maintainer_names").max_length or 120
+        if len(maintainer_names) > max_name_length:
+            raise ValidationError(
+                f"reported_by_name is too long (max {max_name_length} characters)"
+            )
+
+        with transaction.atomic():
+            entry = LogEntry.objects.create(
+                machine=report.machine,
+                problem_report=report,
+                text=text,
+                occurred_at=_parse_occurred_at(body.get("occurred_at")),
+                maintainer_names=maintainer_names,
+            )
+
+        return JsonResponse({"log_entry": _serialize_log_entry(entry)}, status=201)

--- a/flipfix/apps/core/views/api.py
+++ b/flipfix/apps/core/views/api.py
@@ -40,6 +40,9 @@ def _parse_occurred_at(raw):
     """
     if not raw:
         return timezone.now()
+    if not isinstance(raw, str):
+        # parse_datetime() raises TypeError on non-strings; surface a 400, not a 500.
+        raise ValidationError("Invalid occurred_at: expected an ISO-8601 datetime string")
     occurred_at = parse_datetime(raw)
     if occurred_at is None:
         raise ValidationError("Invalid occurred_at: expected an ISO-8601 datetime")

--- a/flipfix/urls.py
+++ b/flipfix/urls.py
@@ -43,6 +43,7 @@ from flipfix.apps.core.views.api import (
     MachineDetailApiView,
     MachineListApiView,
     MachineProblemReportCreateApiView,
+    ProblemReportLogEntryCreateApiView,
 )
 from flipfix.apps.core.views.feed import GlobalActivityFeedPartialView
 from flipfix.apps.core.views.health import healthz
@@ -430,6 +431,13 @@ urlpatterns = [
         "api/v1/machines/<str:asset_id>/problem-reports/",
         MachineProblemReportCreateApiView.as_view(),
         name="api-v1-machine-problem-report-create",
+        access="always_public",
+    ),
+    # Write: append a log entry to a problem report (requires can_write key)
+    path(
+        "api/v1/problem-reports/<int:pk>/log-entries/",
+        ProblemReportLogEntryCreateApiView.as_view(),
+        name="api-v1-problem-report-log-entry-create",
         access="always_public",
     ),
     # Worker: download source video for transcoding


### PR DESCRIPTION
## Summary

Adds **`POST /api/v1/problem-reports/<pk>/log-entries/`** (requires a `can_write` key) — the recurrence companion to the idempotent problem-report create endpoint from #350/PR #351.

Closes #352.

### Why
The problem-report create endpoint is idempotent: when an `unplayable` report is already open for a machine, a recurrence returns `200` with the existing report and records **nothing new**. So juice shutting an already-broken machine down *again* (to stop it overheating) left no trace. juice already captures the returned `problem_report.id` (juice PR #32) and wants to append a log entry to it — this endpoint provides that.

### What's included
- New `ProblemReportLogEntryCreateApiView`, mirroring `MachineProblemReportCreateApiView` (write scope, `csrf_exempt`, `json_api_view`). **No migration** — `maintenance.LogEntry` already has every field needed.
- Body: `text` (required), `occurred_at` (optional ISO-8601, default now), `reported_by_name` (optional). `reported_by_name` → `LogEntry.maintainer_names`, **defaulting to the key's `app_name`** when omitted so the model's "a maintainer or a name is required" `clean()` invariant holds and entries always carry attribution.
- Creating the entry fires the existing Discord **#logs** webhook (async, on-commit) and links to the report's machine, so it appears on both the report and machine timelines.
- **Refactor:** extracted shared `_load_json_body` / `_parse_occurred_at` helpers, now used by both write views (no behavior change to the problem-report endpoint).
- Docs (`docs/API.md`) updated with the new endpoint.

### Responses
`201` created · `400` missing/empty `text`, bad `occurred_at`, malformed JSON, or `reported_by_name` > 120 chars · `404` unknown report pk · `401/403` auth/write-scope.

## Testing
- New `test_log_entry_api.py` (14 tests: auth/scope, create, attribution + app_name fallback, occurred_at override, validation 400s, 404).
- `make test` — **1903 passed** (incl. regression on the refactored problem-report endpoint); `make quality` — clean (ruff + mypy).

## Note
Org CodeRabbit credits were exhausted last session, so automated review may still be degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint for adding log entries to problem reports
  * Supports optional timestamp override and custom reporter attribution
  * Includes comprehensive input validation and error handling

* **Documentation**
  * Added API documentation with usage examples and error specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->