### PR TITLE
fix(deploy): run web gunicorn with 2 workers, 4 threads, 60s timeout

### DIFF
--- a/railpack.web.json
+++ b/railpack.web.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.railpack.com",
   "deploy": {
-    "startCommand": "DJANGO_SETTINGS_MODULE=flipfix.settings.web python manage.py migrate && python manage.py collectstatic --noinput && gunicorn --bind 0.0.0.0:${PORT:-8000} flipfix.wsgi:application"
+    "startCommand": "DJANGO_SETTINGS_MODULE=flipfix.settings.web python manage.py migrate && python manage.py collectstatic --noinput && gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 2 --threads 4 --timeout 60 flipfix.wsgi:application"
   }
 }


### PR DESCRIPTION
## What & why

The `web` service launched gunicorn with **no `--workers` (default: 1 sync worker)** and **no `--timeout` (default: 30s)**. With a single sync worker, *any* slow request blocks all traffic, and at 30s gunicorn kills the worker — surfacing to the user as a 500.

This is exactly what happened in production on 2026-06-21 ~17:37 Central: a maintainer uploaded a large transparent PNG with a problem report; the synchronous image re-encode ran the full 30s and was killed (`[CRITICAL] WORKER TIMEOUT`), returning a 500. It recurred on their retry.

## Change

```
gunicorn --bind 0.0.0.0:${PORT:-8000} flipfix.wsgi:application
# becomes
gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 2 --threads 4 --timeout 60 flipfix.wsgi:application
```

- `--workers 2 --threads 4` (auto-selects the gthread worker) gives concurrency so a single slow request no longer stalls the whole site (PIL/zlib and DB I/O release the GIL).
- `--timeout 60` adds headroom.

Deploy-config only — no application code changes.

## Caveat — verify memory headroom
Two workers roughly doubles resident memory vs. one. If the Railway `web` instance is memory-constrained and OOMs after deploy, dial back to a single worker with more threads (concurrency at lower memory cost):

```
--workers 1 --threads 8 --timeout 60
```

## Note — not a complete fix for the upload timeout
This removes the site-wide stall and the single-worker bottleneck, but the underlying slow path (synchronous PNG re-encode with `optimize=True` on large/transparent images) is unchanged — a sufficiently large image could still hit the 60s timeout. Mitigated operationally for now by guiding maintainers to upload photos as JPEG rather than large PNGs. A code-level fix (drop PNG `optimize=True`, add a pixel-count guard) was scoped but deferred.

## Verification
- `railpack.web.json` validated as well-formed JSON; pre-commit hooks pass.
- After merge/deploy, confirm the gunicorn start line in Railway `web` logs shows the new workers/threads/timeout, and watch for absence of `WORKER TIMEOUT` and any OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to optimize application performance and reliability through enhanced resource allocation and request timeout settings, ensuring more stable service delivery under varying operational conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->