### PR TITLE
feat(qr): asset-ID QR URLs, richer report form, bulk-print controls

### DIFF
--- a/flipfix/apps/core/qr.py
+++ b/flipfix/apps/core/qr.py
@@ -14,7 +14,7 @@ from qrcode.constants import ERROR_CORRECT_H
 
 # QR code configuration
 QR_BOX_SIZE_SINGLE = 10  # Larger boxes for single QR display
-QR_BOX_SIZE_BULK = 8  # Smaller boxes for bulk printing
+QR_BOX_SIZE_BULK = 10  # Keep bulk rasters crisp when scaled up to the chosen print size
 QR_BORDER = 4
 QR_LOGO_SIZE_RATIO = 0.28  # Logo takes 28% of QR width (within 30% error correction)
 QR_LOGO_SIZE_RATIO_BULK = 0.25  # Slightly smaller for bulk

--- a/flipfix/apps/maintenance/forms.py
+++ b/flipfix/apps/maintenance/forms.py
@@ -18,7 +18,7 @@ from flipfix.apps.maintenance.models import LogEntry, MaintenanceTaskType, Probl
 
 class ProblemReportForm(StyledFormMixin, forms.ModelForm):
     machine_slug = forms.CharField(required=False, widget=forms.HiddenInput())
-    media_file = MultiFileField(label="Photo", required=False)
+    media_file = MultiFileField(label="Photo or video", required=False)
 
     class Meta:
         model = ProblemReport

--- a/flipfix/apps/maintenance/forms.py
+++ b/flipfix/apps/maintenance/forms.py
@@ -18,31 +18,36 @@ from flipfix.apps.maintenance.models import LogEntry, MaintenanceTaskType, Probl
 
 class ProblemReportForm(StyledFormMixin, forms.ModelForm):
     machine_slug = forms.CharField(required=False, widget=forms.HiddenInput())
+    media_file = MultiFileField(label="Photo", required=False)
 
     class Meta:
         model = ProblemReport
-        fields = ["problem_type", "description"]
-        widgets = {
-            "problem_type": forms.RadioSelect(),
+        fields = ["description"]
+        # Annotated with the base Widget type so subclasses can override with
+        # other widget classes (e.g. the maintainer form's Select for priority).
+        widgets: dict[str, forms.Widget] = {
             "description": forms.Textarea(
-                attrs={"rows": 4, "placeholder": "Describe the problem..."}
+                attrs={
+                    "rows": 4,
+                    "placeholder": "stuck ball, sticky flipper, target not working...",
+                }
             ),
         }
         labels = {
-            "problem_type": "What type of problem?",
-            "description": "",
+            "description": "What's wrong?",
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # A report must describe the problem: it's now the only substantive field.
+        self.fields["description"].required = True
 
     def clean_machine_slug(self):
         return clean_machine_slug(self.cleaned_data)
 
-    def clean(self):
-        cleaned = super().clean()
-        problem_type = cleaned.get("problem_type")
-        description = (cleaned.get("description") or "").strip()
-        if problem_type == ProblemReport.ProblemType.OTHER and not description:
-            self.add_error("description", "Please describe the problem.")
-        return cleaned
+    def clean_media_file(self):
+        """Validate uploaded media (photos or video). Supports multiple files."""
+        return clean_media_files(self.files, self.cleaned_data)
 
 
 class MaintainerProblemReportForm(ProblemReportForm):
@@ -54,15 +59,14 @@ class MaintainerProblemReportForm(ProblemReportForm):
 
     class Meta(ProblemReportForm.Meta):
         fields = ["description", "priority", "occurred_at"]
-        widgets = {
-            **ProblemReportForm.Meta.widgets,
+        # Annotated so the mixed widget types (Textarea + Select) share a base type.
+        widgets: dict[str, forms.Widget] = {
             "description": MarkdownTextarea(
                 attrs={"rows": 4, "placeholder": "Describe the problem..."}
             ),
             "priority": forms.Select(),
         }
         labels = {
-            **ProblemReportForm.Meta.labels,
             "description": "Description",
         }
 
@@ -77,7 +81,7 @@ class MaintainerProblemReportForm(ProblemReportForm):
         widget=forms.TextInput(attrs={"placeholder": "Who is reporting this?"}),
     )
 
-    media_file = MultiFileField(label="Photo", required=False)
+    # media_file and clean_media_file are inherited from ProblemReportForm.
 
     # occurred_at is optional; model has default=timezone.now.
     # JS pre-fills client-side, but tests/API can omit it.
@@ -92,10 +96,6 @@ class MaintainerProblemReportForm(ProblemReportForm):
     def clean_description(self):
         """Convert authoring format links to storage format."""
         return clean_markdown_field(self.cleaned_data, "description")
-
-    def clean_media_file(self):
-        """Validate uploaded media (photo or video). Supports multiple files."""
-        return clean_media_files(self.files, self.cleaned_data)
 
     def clean_occurred_at(self):
         """Default to now if occurred_at is empty."""

--- a/flipfix/apps/maintenance/templatetags/maintenance_tags.py
+++ b/flipfix/apps/maintenance/templatetags/maintenance_tags.py
@@ -291,5 +291,5 @@ def report_problem_button(context, machine, btn_class="btn btn--report", label="
     if can_access_maintainer_portal(context["user"]):
         url = reverse("problem-report-create-machine", kwargs={"slug": machine.slug})
     else:
-        url = reverse("public-problem-report-create", kwargs={"slug": machine.slug})
+        url = reverse("public-problem-report-create", kwargs={"code": machine.asset_id})
     return {"url": url, "btn_class": btn_class, "label": label}

--- a/flipfix/apps/maintenance/tests/test_problem_report_create.py
+++ b/flipfix/apps/maintenance/tests/test_problem_report_create.py
@@ -24,7 +24,7 @@ class ProblemReportCreateViewTests(TestDataMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.url = reverse("public-problem-report-create", kwargs={"slug": self.machine.slug})
+        self.url = reverse("public-problem-report-create", kwargs={"code": self.machine.asset_id})
 
     def test_create_view_accessible_without_login(self):
         """Problem report form should be accessible to anonymous users."""
@@ -37,12 +37,52 @@ class ProblemReportCreateViewTests(TestDataMixin, TestCase):
         response = self.client.get(self.url)
         self.assertContains(response, self.machine.name)
 
+    def test_resolves_by_asset_id_case_insensitively(self):
+        """The QR route resolves a machine by its asset ID, ignoring case."""
+        url = reverse(
+            "public-problem-report-create",
+            kwargs={"code": self.machine.asset_id.lower()},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["machine"], self.machine)
+
+    def test_resolves_by_legacy_slug(self):
+        """Older QR codes encoding the machine slug still resolve (backward compat)."""
+        url = reverse("public-problem-report-create", kwargs={"code": self.machine.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["machine"], self.machine)
+
+    def test_legacy_slug_submission_creates_report(self):
+        """A report submitted via a legacy slug URL is created and redirects."""
+        url = reverse("public-problem-report-create", kwargs={"code": self.machine.slug})
+        response = self.client.post(url, {"description": "Ball stuck"}, REMOTE_ADDR="192.168.1.100")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ProblemReport.objects.count(), 1)
+        self.assertEqual(ProblemReport.objects.first().machine, self.machine)
+
+    def test_unknown_code_returns_404(self):
+        """A code matching neither an asset ID nor a slug returns 404."""
+        url = reverse("public-problem-report-create", kwargs={"code": "no-such-machine"})
+        self.assertEqual(self.client.get(url).status_code, 404)
+
+    def test_form_has_no_problem_type_field(self):
+        """The problem-type radios were removed from the public form."""
+        response = self.client.get(self.url)
+        self.assertNotContains(response, 'name="problem_type"')
+        self.assertNotIn("problem_type", response.context["form"].fields)
+
+    def test_description_is_required(self):
+        """An empty submission is rejected: describing the problem is required."""
+        response = self.client.post(self.url, {"description": ""}, REMOTE_ADDR="192.168.1.100")
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response.context["form"], "description", "This field is required.")
+        self.assertEqual(ProblemReport.objects.count(), 0)
+
     def test_create_problem_report_success(self):
         """Successfully creating a problem report should save it with correct data."""
-        data = {
-            "problem_type": ProblemReport.ProblemType.STUCK_BALL,
-            "description": "Ball is stuck behind the bumpers",
-        }
+        data = {"description": "Ball is stuck behind the bumpers"}
         response = self.client.post(self.url, data, REMOTE_ADDR="192.168.1.100")
 
         self.assertEqual(response.status_code, 302)
@@ -51,40 +91,22 @@ class ProblemReportCreateViewTests(TestDataMixin, TestCase):
         self.assertEqual(ProblemReport.objects.count(), 1)
         report = ProblemReport.objects.first()
         self.assertEqual(report.machine, self.machine)
-        self.assertEqual(report.problem_type, ProblemReport.ProblemType.STUCK_BALL)
+        # Public reports no longer collect a type; it falls back to the model default.
+        self.assertEqual(report.problem_type, ProblemReport.ProblemType.OTHER)
         self.assertEqual(report.description, "Ball is stuck behind the bumpers")
         self.assertEqual(report.status, ProblemReport.Status.OPEN)
         self.assertEqual(report.ip_address, "192.168.1.100")
 
     def test_visitor_report_gets_untriaged_priority(self):
         """Public submissions should always be set to UNTRIAGED priority."""
-        data = {
-            "problem_type": ProblemReport.ProblemType.STUCK_BALL,
-            "description": "Ball stuck",
-        }
-        self.client.post(self.url, data, REMOTE_ADDR="192.168.1.100")
+        self.client.post(self.url, {"description": "Ball stuck"}, REMOTE_ADDR="192.168.1.100")
 
         report = ProblemReport.objects.first()
         self.assertEqual(report.priority, ProblemReport.Priority.UNTRIAGED)
 
-    def test_create_problem_report_with_other_type(self):
-        """Problem type can be explicitly set to 'other'."""
-        data = {
-            "problem_type": ProblemReport.ProblemType.OTHER,
-            "description": "Something is wrong",
-        }
-        response = self.client.post(self.url, data, REMOTE_ADDR="192.168.1.100")
-
-        self.assertEqual(response.status_code, 302)
-        report = ProblemReport.objects.first()
-        self.assertEqual(report.problem_type, ProblemReport.ProblemType.OTHER)
-
     def test_create_problem_report_captures_user_agent(self):
         """Problem report should capture the User-Agent header."""
-        data = {
-            "problem_type": ProblemReport.ProblemType.NO_CREDITS,
-            "description": "Credits not working",
-        }
+        data = {"description": "Credits not working"}
         self.client.post(
             self.url,
             data,

--- a/flipfix/apps/maintenance/tests/test_problem_report_media.py
+++ b/flipfix/apps/maintenance/tests/test_problem_report_media.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from constance.test import override_config
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, tag
 from django.urls import reverse
@@ -67,13 +68,46 @@ class ProblemReportMediaCreateTests(TemporaryMediaMixin, TestDataMixin, TestCase
         self.assertEqual(report.problem_type, ProblemReport.ProblemType.OTHER)
         self.assertEqual(report.media.count(), 0)
 
-    def test_public_form_has_no_media_field(self):
-        """Public problem report form should not have media upload field."""
-        public_url = reverse("public-problem-report-create", kwargs={"slug": self.machine.slug})
+    def test_public_form_has_media_field(self):
+        """Public problem report form now offers a media upload field."""
+        public_url = reverse("public-problem-report-create", kwargs={"code": self.machine.asset_id})
         response = self.client.get(public_url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, 'name="media_file"')
+        self.assertContains(response, 'name="media_file"')
+
+    def test_public_photo_upload_attaches_media(self):
+        """A visitor can attach a photo to a public problem report."""
+        public_url = reverse("public-problem-report-create", kwargs={"code": self.machine.asset_id})
+        response = self.client.post(
+            public_url,
+            {"description": "Ball stuck", "media_file": create_uploaded_image()},
+            REMOTE_ADDR="192.168.1.100",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        report = ProblemReport.objects.get()
+        self.assertEqual(report.priority, ProblemReport.Priority.UNTRIAGED)
+        self.assertEqual(report.media.count(), 1)
+        self.assertEqual(report.media.first().media_type, ProblemReportMedia.MediaType.PHOTO)
+
+    @patch("flipfix.apps.core.media_upload.enqueue_transcode")
+    def test_public_video_upload_enqueues_transcode(self, mock_enqueue):
+        """A visitor video upload attaches media and schedules transcoding."""
+        public_url = reverse("public-problem-report-create", kwargs={"code": self.machine.asset_id})
+        video_file = SimpleUploadedFile("test.mp4", b"fake video content", content_type="video/mp4")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                public_url,
+                {"description": "Flipper broke, see video", "media_file": video_file},
+                REMOTE_ADDR="192.168.1.100",
+            )
+
+        self.assertEqual(response.status_code, 302)
+        media = ProblemReportMedia.objects.get()
+        self.assertEqual(media.media_type, ProblemReportMedia.MediaType.VIDEO)
+        mock_enqueue.assert_called_once_with(media_id=media.id, model_name="ProblemReportMedia")
 
     @patch("flipfix.apps.core.media_upload.enqueue_transcode")
     def test_form_video_upload_enqueues_transcode(self, mock_enqueue):
@@ -339,3 +373,41 @@ class ProblemReportDetailMediaDisplayTests(TemporaryMediaMixin, TestDataMixin, T
 
         self.assertContains(response, "media-grid__item")
         self.assertNotContains(response, "No media.")
+
+
+@tag("views")
+class UntriagedMediaVisibilityTests(TemporaryMediaMixin, TestDataMixin, TestCase):
+    """Untriaged (unreviewed) visitor media must be hidden from the public."""
+
+    def _report_with_media(self, priority):
+        report = create_problem_report(
+            machine=self.machine, description="Test problem", priority=priority
+        )
+        img_file = create_uploaded_image()
+        ProblemReportMedia.objects.create(
+            problem_report=report,
+            media_type=ProblemReportMedia.MediaType.PHOTO,
+            file=SimpleUploadedFile("test.jpg", img_file.read(), content_type="image/jpeg"),
+        )
+        return reverse("problem-report-detail", kwargs={"pk": report.pk})
+
+    @override_config(PUBLIC_ACCESS_ENABLED=True)
+    def test_untriaged_media_hidden_from_anonymous(self):
+        """Anonymous visitors see no media on an untriaged report."""
+        url = self._report_with_media(ProblemReport.Priority.UNTRIAGED)
+        response = self.client.get(url)
+        self.assertNotContains(response, "media-grid__item")
+
+    def test_untriaged_media_visible_to_maintainer(self):
+        """Logged-in maintainers still see media on an untriaged report."""
+        url = self._report_with_media(ProblemReport.Priority.UNTRIAGED)
+        self.client.force_login(self.maintainer_user)
+        response = self.client.get(url)
+        self.assertContains(response, "media-grid__item")
+
+    @override_config(PUBLIC_ACCESS_ENABLED=True)
+    def test_triaged_media_visible_to_anonymous(self):
+        """The guard only affects untriaged reports; triaged media stays public."""
+        url = self._report_with_media(ProblemReport.Priority.MINOR)
+        response = self.client.get(url)
+        self.assertContains(response, "media-grid__item")

--- a/flipfix/apps/maintenance/tests/test_qr_codes.py
+++ b/flipfix/apps/maintenance/tests/test_qr_codes.py
@@ -44,3 +44,15 @@ class MachineBulkQRCodeViewAccessTests(SuppressRequestLogsMixin, TestDataMixin, 
         self.client.force_login(self.superuser)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
+
+    def test_shows_report_a_problem_label_and_controls(self):
+        """The bulk page labels each QR and offers size + machine-selection controls."""
+        self.client.force_login(self.maintainer_user)
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "Report a Problem")
+        self.assertContains(response, self.machine.name)
+        self.assertContains(response, "data-qr-size-input")
+        self.assertContains(response, "data-qr-machine-toggle")
+        # Each card carries its machine id so JS can toggle print visibility.
+        self.assertContains(response, f'data-machine-id="{self.machine.pk}"')

--- a/flipfix/apps/maintenance/views/problem_reports.py
+++ b/flipfix/apps/maintenance/views/problem_reports.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 
 from django.conf import settings
 from django.contrib import messages
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -92,6 +93,12 @@ class ProblemReportLogEntriesPartialView(InfiniteScrollMixin, View):
         )
 
 
+# Newly printed QR codes encode the machine's asset ID (e.g. M0001); older ones
+# encode the slug. A single route resolves both, trying the asset ID first when the
+# code matches the asset-ID shape so legacy slug codes keep working unchanged.
+_ASSET_ID_RE = re.compile(rf"^{re.escape(MachineInstance.ASSET_ID_PREFIX)}\d+$", re.IGNORECASE)
+
+
 class PublicProblemReportCreateView(FormView):
     """Public-facing problem report submission (minimal shell)."""
 
@@ -99,8 +106,20 @@ class PublicProblemReportCreateView(FormView):
     form_class = ProblemReportForm
 
     def dispatch(self, request, *args, **kwargs):
-        self.machine = get_object_or_404(MachineInstance, slug=kwargs["slug"])
+        code = kwargs["code"]
+        machine = None
+        if _ASSET_ID_RE.match(code):
+            machine = MachineInstance.objects.filter(asset_id__iexact=code).first()
+        if machine is None:
+            machine = MachineInstance.objects.filter(slug=code).first()
+        if machine is None:
+            raise Http404("No machine matches the given code.")
+        self.machine = machine
         return super().dispatch(request, *args, **kwargs)
+
+    def _self_url_code(self) -> str:
+        """Canonical code for redirecting back to this form (asset ID preferred)."""
+        return self.machine.asset_id or self.machine.slug
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -112,7 +131,7 @@ class PublicProblemReportCreateView(FormView):
         ip_address = get_real_ip(request)
         if ip_address and not self._check_rate_limit(ip_address):
             messages.error(request, "Too many reports submitted recently. Please try again later.")
-            return redirect("public-problem-report-create", slug=self.machine.slug)
+            return redirect("public-problem-report-create", code=self._self_url_code())
         return super().post(request, *args, **kwargs)
 
     def _check_rate_limit(self, ip_address: str) -> bool:
@@ -122,6 +141,7 @@ class PublicProblemReportCreateView(FormView):
         ).count()
         return recent_reports < settings.RATE_LIMIT_REPORTS_PER_IP
 
+    @transaction.atomic
     def form_valid(self, form):
         report = form.save(commit=False)
         report.machine = self.machine
@@ -131,8 +151,19 @@ class PublicProblemReportCreateView(FormView):
         if self.request.user.is_authenticated:
             report.reported_by_user = self.request.user
         report.save()
+
+        # Attach any photos/videos the reporter uploaded. Must run inside the
+        # transaction: attach_media_files schedules video transcoding on_commit.
+        media_files = form.cleaned_data.get("media_file", [])
+        if media_files:
+            attach_media_files(
+                media_files=media_files,
+                parent=report,
+                media_model=ProblemReportMedia,
+            )
+
         messages.success(self.request, "Thanks! The maintenance team has been notified.")
-        return redirect("public-problem-report-create", slug=self.machine.slug)
+        return redirect("public-problem-report-create", code=self._self_url_code())
 
 
 class ProblemReportCreateView(FormPrefillMixin, SharedAccountMixin, FormView):

--- a/flipfix/apps/maintenance/views/qr_codes.py
+++ b/flipfix/apps/maintenance/views/qr_codes.py
@@ -23,7 +23,7 @@ class MachineQRView(DetailView):
         machine = self.object
 
         public_url = self.request.build_absolute_uri(
-            reverse("public-problem-report-create", args=[machine.slug])
+            reverse("public-problem-report-create", args=[machine.asset_id])
         )
 
         context["qr_code_data"] = generate_qr_code_base64(public_url)
@@ -44,7 +44,7 @@ class MachineBulkQRCodeView(TemplateView):
 
         for machine in machines:
             public_url = self.request.build_absolute_uri(
-                reverse("public-problem-report-create", args=[machine.slug])
+                reverse("public-problem-report-create", args=[machine.asset_id])
             )
             qr_entries.append(
                 {

--- a/flipfix/static/core/qr_print_controls.js
+++ b/flipfix/static/core/qr_print_controls.js
@@ -1,0 +1,100 @@
+/**
+ * Bulk QR print controls.
+ *
+ * Progressive enhancement for the bulk QR print page: lets the user pick the
+ * printed QR size (in decimal inches) and choose which machines to include,
+ * with a live on-screen preview. With JS disabled the page still renders every
+ * QR at the default size and prints all of them.
+ *
+ * Auto-initializes on DOMContentLoaded for elements with [data-qr-print-controls].
+ *
+ * Expected DOM:
+ *   <div data-qr-print-controls data-qr-grid-selector=".qr-grid">
+ *     <input type="number" data-qr-size-input value="2.0">
+ *     <button data-qr-select-all>…</button>
+ *     <button data-qr-select-none>…</button>
+ *     <input type="checkbox" value="<machine-id>" data-qr-machine-toggle checked>
+ *     …
+ *   </div>
+ *   <div class="qr-grid">
+ *     <div class="qr-card" data-machine-id="<machine-id>">…</div>
+ *     …
+ *   </div>
+ *
+ * Sizing is driven by the `--qr-print-size` custom property set on the grid;
+ * the stylesheet consumes it for `.qr-card__image` width/height and the grid
+ * column sizing. CSS inches map to physical inches when printing.
+ *
+ * Selection toggles the shared `.hidden` (display:none) utility on each card,
+ * which also removes hidden cards from the printed output.
+ */
+
+(function () {
+  'use strict';
+
+  function initQrPrintControls(root) {
+    if (root.dataset.qrPrintControlsInitialized) {
+      return;
+    }
+    root.dataset.qrPrintControlsInitialized = 'true';
+
+    const grid = document.querySelector(root.dataset.qrGridSelector || '.qr-grid');
+    if (!grid) {
+      return;
+    }
+
+    // --- Size control -------------------------------------------------------
+    const sizeInput = root.querySelector('[data-qr-size-input]');
+
+    function applySize() {
+      const inches = parseFloat(sizeInput.value);
+      if (!Number.isFinite(inches) || inches <= 0) {
+        return;
+      }
+      grid.style.setProperty('--qr-print-size', inches + 'in');
+    }
+
+    if (sizeInput) {
+      sizeInput.addEventListener('input', applySize);
+      applySize(); // honor the server-rendered default on load
+    }
+
+    // --- Machine selection --------------------------------------------------
+    const toggles = Array.from(root.querySelectorAll('[data-qr-machine-toggle]'));
+    const cardById = new Map();
+    grid.querySelectorAll('[data-machine-id]').forEach((card) => {
+      cardById.set(card.dataset.machineId, card);
+    });
+
+    function syncCard(toggle) {
+      const card = cardById.get(toggle.value);
+      if (card) {
+        card.classList.toggle('hidden', !toggle.checked);
+      }
+    }
+
+    toggles.forEach((toggle) => {
+      toggle.addEventListener('change', () => syncCard(toggle));
+    });
+
+    function setAll(checked) {
+      toggles.forEach((toggle) => {
+        toggle.checked = checked;
+        syncCard(toggle);
+      });
+    }
+
+    const selectAll = root.querySelector('[data-qr-select-all]');
+    const selectNone = root.querySelector('[data-qr-select-none]');
+    if (selectAll) {
+      selectAll.addEventListener('click', () => setAll(true));
+    }
+    if (selectNone) {
+      selectNone.addEventListener('click', () => setAll(false));
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-qr-print-controls]').forEach(initQrPrintControls);
+  });
+})();

--- a/flipfix/urls.py
+++ b/flipfix/urls.py
@@ -283,9 +283,10 @@ urlpatterns = [
         name="public-machine-detail",
         access="always_public",
     ),
-    # Public problem report form (from QR code)
+    # Public problem report form (from QR code). ``code`` is a machine asset ID
+    # (e.g. M0001) for newly printed codes, or a legacy slug for older ones.
     path(
-        "p/<slug:slug>/",
+        "p/<str:code>/",
         PublicProblemReportCreateView.as_view(),
         name="public-problem-report-create",
         access="always_public",

--- a/templates/maintenance/machine_qr.html
+++ b/templates/maintenance/machine_qr.html
@@ -44,7 +44,7 @@
     <!-- MAIN COLUMN -->
     <div class="two-column__main">
       <div class="card card--padded qr-printable">
-        <h2>Report Problem</h2>
+        <h2>Report a Problem</h2>
         <img src="data:image/png;base64,{{ qr_code_data }}"
              alt="QR Code for {{ machine.name }}"
              class="qr-image">

--- a/templates/maintenance/machine_qr_bulk.html
+++ b/templates/maintenance/machine_qr_bulk.html
@@ -15,13 +15,47 @@
     </div>
     <!-- Sidebar (screen-only) -->
     <aside class="two-column__sidebar no-print">
-      <div class="card card--padded sidebar--sticky">
+      <div class="card card--padded sidebar--sticky"
+           data-qr-print-controls
+           data-qr-grid-selector=".qr-grid">
         <div class="sidebar__section">
           <div class="sidebar__label">QR Codes</div>
           <div class="sidebar__title">Bulk print</div>
           <p class="text-muted text-sm space-above-sm">
             A QR code for every machine, linking to the public problem-report page.
           </p>
+        </div>
+        <div class="sidebar__section">
+          <label for="qr-size-input" class="sidebar__label">QR size (inches)</label>
+          <input type="number"
+                 id="qr-size-input"
+                 class="form-input form-input--width-6 space-above-sm"
+                 min="0.5"
+                 max="6"
+                 step="0.1"
+                 value="2.0"
+                 data-qr-size-input>
+        </div>
+        <div class="sidebar__section">
+          <fieldset class="qr-machine-picker">
+            <legend class="sidebar__label">Machines to print</legend>
+            <div class="qr-machine-picker__actions space-above-sm">
+              <button type="button" class="btn btn--secondary btn--sm" data-qr-select-all>Select all</button>
+              <button type="button" class="btn btn--secondary btn--sm" data-qr-select-none>Select none</button>
+            </div>
+            <div class="qr-machine-picker__list space-above-sm">
+              {% for item in qr_entries %}
+                <label class="checkbox-label">
+                  <input type="checkbox"
+                         class="checkbox"
+                         value="{{ item.machine.pk }}"
+                         data-qr-machine-toggle
+                         checked>
+                  <span>{{ item.machine.name }}</span>
+                </label>
+              {% endfor %}
+            </div>
+          </fieldset>
         </div>
         <div class="sidebar__section">
           <button type="button"
@@ -37,7 +71,8 @@
     <div class="two-column__main">
       <div class="qr-grid">
         {% for item in qr_entries %}
-          <div class="qr-card">
+          <div class="qr-card" data-machine-id="{{ item.machine.pk }}">
+            <div class="qr-card__title">Report a Problem</div>
             <img src="data:image/png;base64,{{ item.qr_data }}"
                  alt="QR for {{ item.machine.name }}"
                  class="qr-card__image">
@@ -52,7 +87,7 @@
   <style>
       .qr-grid {
           display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+          grid-template-columns: repeat(auto-fill, minmax(calc(var(--qr-print-size, 2in) + 2.5rem), 1fr));
           gap: var(--space-4);
       }
 
@@ -69,9 +104,15 @@
           page-break-inside: avoid;
       }
 
+      .qr-card__title {
+          font-weight: var(--font-semibold);
+          text-align: center;
+          color: var(--color-text-primary);
+      }
+
       .qr-card__image {
-          width: 180px;
-          height: 180px;
+          width: var(--qr-print-size, 2in);
+          height: var(--qr-print-size, 2in);
           object-fit: contain;
       }
 
@@ -79,6 +120,25 @@
           font-weight: var(--font-semibold);
           text-align: center;
           color: var(--color-text-primary);
+      }
+
+      .qr-machine-picker {
+          border: none;
+          margin: 0;
+          padding: 0;
+      }
+
+      .qr-machine-picker__actions {
+          display: flex;
+          gap: var(--space-2);
+      }
+
+      .qr-machine-picker__list {
+          max-height: 22rem;
+          overflow-y: auto;
+          display: flex;
+          flex-direction: column;
+          gap: var(--space-1);
       }
 
       @media print {
@@ -113,4 +173,5 @@
           }
       }
   </style>
+  <script src="{% static 'core/qr_print_controls.js' %}" defer></script>
 {% endblock %}

--- a/templates/maintenance/problem_report_detail.html
+++ b/templates/maintenance/problem_report_detail.html
@@ -81,7 +81,11 @@
   <!-- DESCRIPTION CARD -->
   {% include "core/partials/text_card_editable.html" with content=report.description %}
   <!-- MEDIA CARD -->
-  {% include "core/partials/media_card_editable.html" with media_items=report.media.all alt="Problem report photo" model_name="ProblemReportMedia" %}
+  {# Untriaged reports are unreviewed visitor submissions: hide their media from #}
+  {# the public until a maintainer triages. Logged-in maintainers always see it. #}
+  {% if user.is_authenticated or report.priority != report.Priority.UNTRIAGED %}
+    {% include "core/partials/media_card_editable.html" with media_items=report.media.all alt="Problem report photo" model_name="ProblemReportMedia" %}
+  {% endif %}
   <!-- LOG ENTRIES SECTION -->
   <div class="space-above-lg">
     <div class="section-header{% if not log_entries %} section-header--divider{% endif %}">

--- a/templates/maintenance/problem_report_new_public.html
+++ b/templates/maintenance/problem_report_new_public.html
@@ -1,41 +1,20 @@
 {% extends "base_public_minimal.html" %}
-{% load form_tags %}
+{% load form_tags static %}
 {% block title %}Report a Problem with {{ machine.name }} · {{ block.super }}{% endblock %}
 {% block content %}
   <div class="card card--padded">
     <h2 class="space-below-md">Report a Problem with {{ machine.name }}</h2>
-    <form method="post" class="form-main">
+    <form method="post" enctype="multipart/form-data" class="form-main">
       {% csrf_token %}
       {% form_non_field_errors form %}
-      <div class="form-field">
-        <label class="form-label">What's wrong?</label>
-        <div class="radio-group">
-          {% for value, label in form.problem_type.field.choices %}
-            <label class="radio-label">
-              <input type="radio"
-                     name="{{ form.problem_type.html_name }}"
-                     value="{{ value }}"
-                     {% if value == form.problem_type.value or forloop.first and not form.problem_type.value %}checked{% endif %}>
-              {{ label }}
-            </label>
-          {% endfor %}
-        </div>
-        {% field_errors form.problem_type %}
-      </div>
-      <div class="form-field">
-        <label for="{{ form.description.id_for_label }}" class="form-label">
-          Details <span class="text-muted text-xs">(optional)</span>
-        </label>
-        <textarea id="{{ form.description.id_for_label }}"
-                  name="{{ form.description.html_name }}"
-                  class="form-input form-textarea"
-                  placeholder="Any additional details..."
-                  rows="3">{{ form.description.value|default:'' }}</textarea>
-        {% field_errors form.description %}
-      </div>
+      {% form_field form.description %}
+      {% media_file_input form.media_file %}
       <div class="form-actions">
         <button type="submit" class="btn btn--primary btn--full">Submit Report</button>
       </div>
     </form>
   </div>
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{% static 'core/file_accumulator.js' %}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Improves the QR-code (`/qr_codes/`) and public problem-reporting flow:

1. **Asset-ID QR URLs.** New QR codes encode the machine's asset ID (`/p/M0001/`) instead of the slug — short, and stable across renames. The public route (`p/<str:code>/`) resolves an asset ID when the code matches the asset-ID shape (`^M\d+$`, case-insensitive) and otherwise falls back to the slug, so **already-printed slug QR codes keep working**.
2. **"Report a Problem" label** above the QR on the single and bulk pages.
3. **Bulk-print controls.** The bulk page gains a live decimal-inch size input (drives a `--qr-print-size` CSS custom property that maps to real print inches) and a per-machine checkbox picker with select-all/none. Progressive enhancement — with JS off it still prints all at the default size. `QR_BOX_SIZE_BULK` bumped 8→10 so rasters stay crisp when scaled up.
4. **Simpler report form.** The `problem_type` radios are replaced by a single required **"What's wrong?"** field (placeholder *"stuck ball, sticky flipper, target not working…"*).
5. **Photos & video on reports.** `media_file` moved to the base `ProblemReportForm`; the public view attaches uploads via the existing `attach_media_files` infra (no new model/migration).
6. **Untriaged media hidden from guests.** Unreviewed visitor reports (`priority == UNTRIAGED`) omit their media for logged-out visitors; maintainers always see it.

## Notes / trade-offs

- The untriaged-media guard is template-level concealment; the underlying `/media/<uuid>.jpg` URL stays directly fetchable (mitigated by uuid4 filenames). True auth-gated media serving is a separate effort.
- Removing `problem_type` from the form narrowed the base `Meta.widgets` type inference; both `Meta.widgets` are now annotated `dict[str, forms.Widget]` so the maintainer form's `Select` remains valid (fixed properly rather than suppressed).
- `description` is now required on the maintainer form too (it always was in practice) — desirable, and covered by existing tests.

## Testing

- Updated/added tests in `test_problem_report_create`, `test_problem_report_media`, `test_qr_codes`: asset-ID + legacy-slug resolution, unknown-code 404, required description, no `problem_type` field, public photo & video upload, and the untriaged media guard (hidden anon / visible maintainer / visible when triaged).
- Full maintenance app + related suites pass (602 tests). `make quality` clean. New JS passes `node --check`.
- Not machine-verified: in-browser print behaviour of the bulk controls (headless environment) — worth a manual print-preview pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public problem reports now support photo/video uploads.
  * Bulk QR pages now include print controls for QR size and machine selection.
  * QR links and codes now use a more flexible identifier format.

* **Bug Fixes**
  * Public problem reports now resolve both new and legacy QR codes.
  * Submissions now save media reliably and show the correct redirect target.
  * Unreviewed report media is hidden from anonymous visitors while remaining visible to maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->