### PR TITLE
feat(maintenance): seed "Check/replace lights" recurring task

### DIFF
--- a/flipfix/apps/maintenance/migrations/0023_seed_check_replace_lights_task.py
+++ b/flipfix/apps/maintenance/migrations/0023_seed_check_replace_lights_task.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+# Adds "Check/replace lights" to the recurring-maintenance vocabulary. Follows
+# the same pattern as 0020: slug is set explicitly because the historical model
+# used by migrations does not run MaintenanceTaskType.save() (which would
+# otherwise auto-fill the slug). sort_order continues the 10-step sequence.
+SEEDS = [
+    {"name": "Check/replace lights", "slug": "check-replace-lights", "sort_order": 40},
+]
+
+
+def seed(apps, schema_editor):
+    MaintenanceTaskType = apps.get_model("maintenance", "MaintenanceTaskType")
+    for entry in SEEDS:
+        MaintenanceTaskType.objects.get_or_create(slug=entry["slug"], defaults=entry)
+
+
+def unseed(apps, schema_editor):
+    MaintenanceTaskType = apps.get_model("maintenance", "MaintenanceTaskType")
+    MaintenanceTaskType.objects.filter(slug__in=[e["slug"] for e in SEEDS]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("maintenance", "0022_dedupe_log_entries"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed, unseed),
+    ]


### PR DESCRIPTION
## What

Adds **Check/replace lights** to the recurring-maintenance task vocabulary (`MaintenanceTaskType`) via a data migration, so it appears as a "Tasks performed" checkbox on the log-entry report form.

## Why this approach

Tasks are a DB-backed, admin-editable lookup table, so this task could also have been added through the Django admin. This PR uses a **data migration** instead so the task is version-controlled and every environment — including fresh databases — picks it up automatically, matching how the initial three tasks were seeded in `0020_seed_maintenance_task_types`.

## Details

- New migration `0023_seed_check_replace_lights_task`, mirroring the `0020` pattern.
- `slug` set explicitly (the historical model used by migrations doesn't run `save()`, which would otherwise auto-fill it).
- `sort_order = 40`, continuing the existing 10-step sequence.
- Reversible: `RunPython(seed, unseed)`; `get_or_create(slug=...)` is idempotent.

## Testing

- `makemigrations --check` — no model changes pending.
- Applied forward, reversed to `0022`, and re-applied — clean both ways.
- Full maintenance suite: `474 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new recurring maintenance task option: “Check/replace lights.”
  * The task is now available in the maintenance list with a consistent display order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->