### PR TITLE
feat(maintenance): couple Unplayable reports to Broken machine status

### DIFF
--- a/docs/Datamodel.md
+++ b/docs/Datamodel.md
@@ -61,7 +61,11 @@ A model of pinball machine (e.g., "Star Trek", "Godzilla").
 
 ### Machine Instance ([`MachineInstance`](../flipfix/apps/catalog/models.py))
 
-A specific physical machine in the museum (e.g., "Star Trek #2").
+A specific physical machine in the museum (e.g., "Star Trek #2"). Its
+`operational_status` (`OperationalStatus`: Good / Fixing / Broken / Unknown) is
+coupled to its problem reports by an invariant: **an open `Unplayable` report
+forces the machine to `Broken`** (see Problem Report, below). The coupling is
+one-directional — returning a machine to service is always a human decision.
 
 ### Location ([`Location`](../flipfix/apps/catalog/models.py))
 
@@ -71,7 +75,16 @@ Physical location where machines can be placed (e.g., "Main Floor", "Workshop").
 
 ### Problem Report ([`ProblemReport`](../flipfix/apps/maintenance/models.py))
 
-Issue reported by museum visitor.
+Issue reported by a museum visitor or maintainer. `priority` (`Priority`:
+Untriaged / Unplayable / Major / Minor / Task) drives list ordering and is
+coupled to machine status: creating or re-prioritising a report to `Unplayable`
+marks its machine `Broken`, enforced at every write path by
+[`status_rules.enforce_unplayable_breaks_machine`](../flipfix/apps/maintenance/status_rules.py).
+Closing the last open `Unplayable` report does **not** auto-restore the machine;
+instead the UI offers the maintainer a one-click "Set machine to Good?" via
+[`status_rules.machine_status_downgrade_prompt`](../flipfix/apps/maintenance/status_rules.py).
+Pre-existing drift was reconciled once by migration
+`maintenance/0024_reconcile_unplayable_machine_status`.
 
 ### Log Entry ([`LogEntry`](../flipfix/apps/maintenance/models.py))
 

--- a/docs/Models.md
+++ b/docs/Models.md
@@ -258,6 +258,21 @@ photos = media.exclude(thumbnail_file="")
 
 The `__gt=""` pattern works because any non-empty path is greater than `""`, while both NULL and `""` fail the comparison.
 
+## Cross-Model Invariants
+
+When a rule must hold _across_ models (e.g. "an open `Unplayable` problem report
+means the machine is `Broken`"), enforce it with an explicit, well-named helper
+called at each write site rather than a model `save()` override or a signal.
+Helpers can accept the acting user, so audit/log side effects are attributed
+correctly, and they keep the coupling greppable instead of hidden. See
+[`maintenance/status_rules.py`](../flipfix/apps/maintenance/status_rules.py)
+(`enforce_unplayable_breaks_machine`), which the create/priority views and the
+write API all call. Prefer a signal only when the invariant must survive writes
+from code paths you don't control. Back-fill pre-existing violations with a
+one-time data migration whose logic lives in an `apps`-registry function (see
+[`reconcile_machine_status.py`](../flipfix/apps/maintenance/reconcile_machine_status.py)
+and `deduplication.py`) so it is unit-testable against real models.
+
 ## Model Checklist
 
 When creating or modifying models:

--- a/flipfix/apps/core/tests/test_problem_report_api.py
+++ b/flipfix/apps/core/tests/test_problem_report_api.py
@@ -105,8 +105,15 @@ class ProblemReportCreateApiBehaviorTests(TestCase):
             LogEntry.objects.filter(machine=self.machine, text__icontains="Broken").exists()
         )
 
-    def test_without_mark_broken_leaves_status_untouched(self):
+    def test_unplayable_marks_broken_without_mark_broken(self):
+        """An open Unplayable report breaks the machine even without mark_broken."""
         self._post({"priority": "unplayable"})
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, MachineInstance.OperationalStatus.BROKEN)
+
+    def test_non_unplayable_leaves_status_untouched(self):
+        """A non-Unplayable report without mark_broken does not change status."""
+        self._post({"priority": "minor"})
         self.machine.refresh_from_db()
         self.assertEqual(self.machine.operational_status, MachineInstance.OperationalStatus.GOOD)
 

--- a/flipfix/apps/core/views/api.py
+++ b/flipfix/apps/core/views/api.py
@@ -17,6 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 from flipfix.apps.catalog.models import MachineInstance
 from flipfix.apps.core.api_auth import json_api_view, validate_api_key
 from flipfix.apps.maintenance.models import LogEntry, ProblemReport
+from flipfix.apps.maintenance.status_rules import enforce_unplayable_breaks_machine
 
 
 def _load_json_body(request) -> dict:
@@ -175,6 +176,8 @@ class MachineProblemReportCreateApiView(View):
                 .first()
             )
             if existing is not None:
+                # Repair any drift: an open unplayable report means broken.
+                enforce_unplayable_breaks_machine(existing)
                 return JsonResponse(
                     {"problem_report": _serialize_problem_report(existing)}, status=200
                 )
@@ -188,6 +191,8 @@ class MachineProblemReportCreateApiView(View):
                 reported_by_name=payload["reported_by_name"],
                 occurred_at=payload["occurred_at"],
             )
+            # An open Unplayable report means the machine is broken.
+            enforce_unplayable_breaks_machine(report)
             if payload["mark_broken"] and (
                 machine.operational_status != MachineInstance.OperationalStatus.BROKEN
             ):

--- a/flipfix/apps/core/views/api.py
+++ b/flipfix/apps/core/views/api.py
@@ -172,6 +172,7 @@ class MachineProblemReportCreateApiView(View):
                     status=ProblemReport.Status.OPEN,
                     priority=ProblemReport.Priority.UNPLAYABLE,
                 )
+                .select_related("machine")
                 .order_by("-occurred_at")
                 .first()
             )

--- a/flipfix/apps/maintenance/migrations/0024_reconcile_unplayable_machine_status.py
+++ b/flipfix/apps/maintenance/migrations/0024_reconcile_unplayable_machine_status.py
@@ -1,0 +1,26 @@
+"""One-time cleanup: mark machines with an open Unplayable report as Broken.
+
+Enforces the invariant introduced alongside this migration (see
+``flipfix.apps.maintenance.status_rules``).  One-directional and irreversible:
+we can't tell a machine broken by this cleanup from one broken for other
+reasons, so the reverse is a no-op.
+"""
+
+from django.db import migrations
+
+from flipfix.apps.maintenance.reconcile_machine_status import (
+    reconcile_unplayable_machine_status,
+)
+
+
+def forward(apps, schema_editor):
+    reconcile_unplayable_machine_status(apps)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("maintenance", "0023_seed_check_replace_lights_task"),
+        ("catalog", "0021_merge_20260316_0036"),
+    ]
+
+    operations = [migrations.RunPython(forward, migrations.RunPython.noop)]

--- a/flipfix/apps/maintenance/reconcile_machine_status.py
+++ b/flipfix/apps/maintenance/reconcile_machine_status.py
@@ -1,0 +1,60 @@
+"""One-time reconciliation of the Unplayable → Broken invariant.
+
+Historically a machine's ``operational_status`` and its problem reports drifted
+apart, so a machine could show ``Good`` while carrying an open ``Unplayable``
+report.  :func:`reconcile_unplayable_machine_status` brings existing rows into
+line with the rule now enforced at write time by
+:mod:`flipfix.apps.maintenance.status_rules`.
+
+The entry point takes the Django ``apps`` registry rather than concrete model
+classes so it runs unchanged against the frozen models inside a data migration
+(the ``apps`` handed to ``RunPython``) and the real models from a test
+(``from django.apps import apps``) — mirroring
+:mod:`flipfix.apps.maintenance.deduplication`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Literal choice values (frozen models don't expose the TextChoices helpers).
+# These mirror MachineInstance.OperationalStatus and ProblemReport.Status/Priority.
+_BROKEN = "broken"
+_OPEN = "open"
+_UNPLAYABLE = "unplayable"
+
+_CLEANUP_LOG_TEXT = "Status set to Broken to match an open Unplayable report (automated cleanup)"
+
+
+def reconcile_unplayable_machine_status(apps, *, log: Callable[[str], None] = print) -> dict:
+    """Mark every machine with an open Unplayable report as Broken.
+
+    One-directional: machines that are Broken *without* an open Unplayable
+    report are left untouched (they may be broken for other reasons).  Each
+    machine fixed here gets a documenting ``LogEntry`` so the change is visible
+    on the timeline.  Deliberately does **not** write a
+    ``HistoricalMachineInstance`` row — this is a data cleanup, not a user
+    action.  Returns and logs an ``{"updated": n}`` summary.
+    """
+    machine_instance = apps.get_model("catalog", "MachineInstance")
+    problem_report = apps.get_model("maintenance", "ProblemReport")
+    log_entry = apps.get_model("maintenance", "LogEntry")
+
+    machine_ids = (
+        problem_report.objects.filter(status=_OPEN, priority=_UNPLAYABLE)
+        .values_list("machine_id", flat=True)
+        .distinct()
+    )
+    drifted = machine_instance.objects.filter(id__in=machine_ids).exclude(
+        operational_status=_BROKEN
+    )
+
+    updated = 0
+    for machine in drifted:
+        machine.operational_status = _BROKEN
+        machine.save(update_fields=["operational_status", "updated_at"])
+        log_entry.objects.create(machine=machine, text=_CLEANUP_LOG_TEXT, created_by=None)
+        updated += 1
+
+    log(f"reconcile_unplayable_machine_status: marked {updated} machine(s) broken")
+    return {"updated": updated}

--- a/flipfix/apps/maintenance/status_rules.py
+++ b/flipfix/apps/maintenance/status_rules.py
@@ -1,0 +1,108 @@
+"""Rules coupling problem-report priority to machine operational status.
+
+The invariant enforced here: **an open ``Unplayable`` problem report means the
+machine is ``Broken``.**  The coupling is deliberately *one-directional* — we
+mark a machine broken automatically, but never un-break it automatically, since
+a machine can be broken for reasons unrelated to any report.  Returning a
+machine to service is a human decision, surfaced by
+:func:`machine_status_downgrade_prompt`.
+
+Both functions operate on real models and are called from views/APIs.  The
+one-time backfill that reconciles pre-existing discrepancies lives in
+:mod:`flipfix.apps.maintenance.reconcile_machine_status`, which takes the app
+registry so it runs unchanged in a data migration (frozen models) and its test
+(real models) — the same split used by
+:mod:`flipfix.apps.maintenance.deduplication`.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Count
+
+from flipfix.apps.catalog.models import MachineInstance
+
+from .models import ProblemReport
+
+
+def enforce_unplayable_breaks_machine(report: ProblemReport, *, actor=None) -> bool:
+    """Mark ``report``'s machine broken if the report is open and unplayable.
+
+    Idempotent and one-directional: only ever sets ``Broken`` and never clears
+    it.  Pass ``actor`` (the user making the change) so the automatic
+    "Status changed" log entry created by the ``MachineInstance`` post_save
+    signal is attributed correctly.  Returns ``True`` if the machine's status
+    was changed.
+    """
+    if report.status != ProblemReport.Status.OPEN:
+        return False
+    if report.priority != ProblemReport.Priority.UNPLAYABLE:
+        return False
+
+    machine = report.machine
+    if machine.operational_status == MachineInstance.OperationalStatus.BROKEN:
+        return False
+
+    machine.operational_status = MachineInstance.OperationalStatus.BROKEN
+    update_fields = ["operational_status", "updated_at"]
+    if actor is not None:
+        machine.updated_by = actor
+        update_fields.append("updated_by")
+    machine.save(update_fields=update_fields)
+    return True
+
+
+def machine_status_downgrade_prompt(closed_report: ProblemReport) -> dict | None:
+    """Return a "set machine to Good?" prompt after closing the last unplayable report.
+
+    Returns ``None`` unless ``closed_report`` is a now-closed ``Unplayable``
+    report whose machine is currently ``Broken`` and has no remaining open
+    ``Unplayable`` reports — i.e. the maintainer just resolved the reason the
+    machine was broken.  The caller is responsible for offering the action; we
+    only build the summary.
+    """
+    if closed_report.priority != ProblemReport.Priority.UNPLAYABLE:
+        return None
+    if closed_report.status != ProblemReport.Status.CLOSED:
+        return None
+
+    machine = closed_report.machine
+    if machine.operational_status != MachineInstance.OperationalStatus.BROKEN:
+        return None
+
+    open_reports = machine.problem_reports.filter(status=ProblemReport.Status.OPEN)
+    if open_reports.filter(priority=ProblemReport.Priority.UNPLAYABLE).exists():
+        return None
+
+    breakdown = _open_priority_breakdown(open_reports)
+    remaining = sum(item["count"] for item in breakdown)
+    return {
+        "message": _downgrade_prompt_message(remaining, breakdown),
+        "remaining_open": remaining,
+        "breakdown": breakdown,
+        "machine_slug": machine.slug,
+    }
+
+
+def _open_priority_breakdown(open_reports) -> list[dict]:
+    """Count open reports per priority, ordered by ``Priority`` enum position."""
+    counts = {
+        row["priority"]: row["count"]
+        for row in open_reports.values("priority").annotate(count=Count("id"))
+    }
+    return [
+        {"priority": value, "label": label, "count": counts[value]}
+        for value, label in ProblemReport.Priority.choices
+        if counts.get(value)
+    ]
+
+
+def _downgrade_prompt_message(remaining: int, breakdown: list[dict]) -> str:
+    """Render the prompt sentence, e.g. 'Last Unplayable report closed. …'."""
+    if remaining == 0:
+        return "Last Unplayable report closed. No open reports remain. Set machine to Good?"
+    detail = ", ".join(f"{item['count']} {item['label']}" for item in breakdown)
+    noun = "report" if remaining == 1 else "reports"
+    return (
+        f"Last Unplayable report closed. {remaining} open {noun} remain "
+        f"({detail}). Set machine to Good?"
+    )

--- a/flipfix/apps/maintenance/tests/test_problem_report_create.py
+++ b/flipfix/apps/maintenance/tests/test_problem_report_create.py
@@ -8,6 +8,7 @@ from django.test import TestCase, tag
 from django.urls import reverse
 from django.utils import timezone
 
+from flipfix.apps.catalog.models import MachineInstance
 from flipfix.apps.core.models import RecordReference
 from flipfix.apps.core.test_utils import (
     DATETIME_INPUT_FORMAT,
@@ -285,6 +286,22 @@ class MaintainerProblemReportCreateViewTests(TestDataMixin, TestCase):
         self.assertEqual(response.status_code, 302)
         report = ProblemReport.objects.first()
         self.assertEqual(report.priority, ProblemReport.Priority.UNPLAYABLE)
+
+    def test_creating_unplayable_report_marks_machine_broken(self):
+        """A maintainer filing an Unplayable report breaks the machine."""
+        self.assertEqual(self.machine.operational_status, MachineInstance.OperationalStatus.GOOD)
+        response = self.client.post(
+            self.url,
+            {
+                "description": "Board is fried",
+                "priority": ProblemReport.Priority.UNPLAYABLE,
+                "occurred_at": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, MachineInstance.OperationalStatus.BROKEN)
 
     def test_create_rejects_future_date(self):
         """View rejects problem reports with future occurred_at dates."""

--- a/flipfix/apps/maintenance/tests/test_problem_report_detail.py
+++ b/flipfix/apps/maintenance/tests/test_problem_report_detail.py
@@ -5,6 +5,7 @@ from django.test import TestCase, tag
 from django.urls import reverse
 
 from flipfix.apps.accounts.models import Maintainer
+from flipfix.apps.catalog.models import MachineInstance
 from flipfix.apps.core.models import RecordReference
 from flipfix.apps.core.test_utils import (
     SuppressRequestLogsMixin,
@@ -411,6 +412,34 @@ class ProblemReportPriorityUpdateTests(SuppressRequestLogsMixin, TestDataMixin, 
 
         self.assertEqual(LogEntry.objects.count(), initial_log_count)
 
+    def test_update_priority_to_unplayable_marks_machine_broken(self):
+        """Raising priority to Unplayable breaks the machine and flags it in JSON."""
+        self.client.force_login(self.maintainer_user)
+
+        response = self.client.post(
+            self.detail_url,
+            {"action": "update_priority", "priority": ProblemReport.Priority.UNPLAYABLE},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["machine_marked_broken"])
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, MachineInstance.OperationalStatus.BROKEN)
+
+    def test_update_priority_to_major_leaves_machine_unchanged(self):
+        """A non-Unplayable priority does not touch machine status."""
+        self.client.force_login(self.maintainer_user)
+
+        response = self.client.post(
+            self.detail_url,
+            {"action": "update_priority", "priority": ProblemReport.Priority.MAJOR},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["machine_marked_broken"])
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, MachineInstance.OperationalStatus.GOOD)
+
 
 @tag("views")
 class ProblemReportStatusUpdateTests(SuppressRequestLogsMixin, TestDataMixin, TestCase):
@@ -491,6 +520,66 @@ class ProblemReportStatusUpdateTests(SuppressRequestLogsMixin, TestDataMixin, Te
         )
 
         self.assertEqual(response.status_code, 400)
+
+    def _make_broken_with_unplayable(self):
+        """Put the machine in Broken with a single open Unplayable report."""
+        self.machine.operational_status = MachineInstance.OperationalStatus.BROKEN
+        self.machine.save(update_fields=["operational_status"])
+        self.report.priority = ProblemReport.Priority.UNPLAYABLE
+        self.report.save(update_fields=["priority"])
+
+    def test_closing_last_unplayable_returns_downgrade_prompt(self):
+        """Closing the last open Unplayable report offers to return to service."""
+        self._make_broken_with_unplayable()
+        create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.MINOR,
+        )
+        self.client.force_login(self.maintainer_user)
+
+        response = self.client.post(
+            self.detail_url,
+            {"action": "update_status", "status": ProblemReport.Status.CLOSED},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        prompt = response.json()["machine_status_prompt"]
+        self.assertEqual(prompt["remaining_open"], 1)
+        self.assertEqual(prompt["machine_slug"], self.machine.slug)
+        self.assertIn("Set machine to Good?", prompt["message"])
+
+    def test_closing_unplayable_with_others_open_no_prompt(self):
+        """No prompt while another open Unplayable report remains."""
+        self._make_broken_with_unplayable()
+        create_problem_report(
+            machine=self.machine,
+            status=ProblemReport.Status.OPEN,
+            priority=ProblemReport.Priority.UNPLAYABLE,
+        )
+        self.client.force_login(self.maintainer_user)
+
+        response = self.client.post(
+            self.detail_url,
+            {"action": "update_status", "status": ProblemReport.Status.CLOSED},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("machine_status_prompt", response.json())
+
+    def test_closing_non_unplayable_report_no_prompt(self):
+        """Closing an ordinary report never prompts, even on a broken machine."""
+        self.machine.operational_status = MachineInstance.OperationalStatus.BROKEN
+        self.machine.save(update_fields=["operational_status"])
+        self.client.force_login(self.maintainer_user)
+
+        response = self.client.post(
+            self.detail_url,
+            {"action": "update_status", "status": ProblemReport.Status.CLOSED},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("machine_status_prompt", response.json())
 
 
 @tag("views")

--- a/flipfix/apps/maintenance/tests/test_status_rules.py
+++ b/flipfix/apps/maintenance/tests/test_status_rules.py
@@ -1,0 +1,228 @@
+"""Tests for the Unplayable → Broken machine-status coupling.
+
+Covers the runtime helpers in
+:mod:`flipfix.apps.maintenance.status_rules` and the one-time backfill in
+:mod:`flipfix.apps.maintenance.reconcile_machine_status`.
+"""
+
+from __future__ import annotations
+
+from django.apps import apps
+from django.test import TestCase, tag
+
+from flipfix.apps.catalog.models import MachineInstance
+from flipfix.apps.core.test_utils import (
+    TestDataMixin,
+    create_machine,
+    create_problem_report,
+)
+from flipfix.apps.maintenance.models import LogEntry, ProblemReport
+from flipfix.apps.maintenance.reconcile_machine_status import (
+    reconcile_unplayable_machine_status,
+)
+from flipfix.apps.maintenance.status_rules import (
+    enforce_unplayable_breaks_machine,
+    machine_status_downgrade_prompt,
+)
+
+Status = ProblemReport.Status
+Priority = ProblemReport.Priority
+OperationalStatus = MachineInstance.OperationalStatus
+
+
+@tag("models")
+class EnforceUnplayableBreaksMachineTests(TestDataMixin, TestCase):
+    """`enforce_unplayable_breaks_machine` sets Broken, one-directionally."""
+
+    def test_open_unplayable_marks_machine_broken(self):
+        report = create_problem_report(
+            machine=self.machine, status=Status.OPEN, priority=Priority.UNPLAYABLE
+        )
+
+        changed = enforce_unplayable_breaks_machine(report)
+
+        self.assertTrue(changed)
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, OperationalStatus.BROKEN)
+
+    def test_no_change_when_report_closed(self):
+        report = create_problem_report(
+            machine=self.machine, status=Status.CLOSED, priority=Priority.UNPLAYABLE
+        )
+
+        self.assertFalse(enforce_unplayable_breaks_machine(report))
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, OperationalStatus.GOOD)
+
+    def test_no_change_when_not_unplayable(self):
+        report = create_problem_report(
+            machine=self.machine, status=Status.OPEN, priority=Priority.MAJOR
+        )
+
+        self.assertFalse(enforce_unplayable_breaks_machine(report))
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, OperationalStatus.GOOD)
+
+    def test_idempotent_when_already_broken(self):
+        machine = create_machine(operational_status=OperationalStatus.BROKEN)
+        report = create_problem_report(
+            machine=machine, status=Status.OPEN, priority=Priority.UNPLAYABLE
+        )
+
+        self.assertFalse(enforce_unplayable_breaks_machine(report))
+        machine.refresh_from_db()
+        self.assertEqual(machine.operational_status, OperationalStatus.BROKEN)
+
+    def test_actor_is_recorded_and_auto_log_attributed(self):
+        create_problem_report(
+            machine=self.machine, status=Status.OPEN, priority=Priority.UNPLAYABLE
+        )
+        # Reload so the machine has no `_skip_auto_log` flag (set by the factory)
+        # and the status-change auto-log signal fires.
+        report = ProblemReport.objects.select_related("machine").get(machine=self.machine)
+
+        changed = enforce_unplayable_breaks_machine(report, actor=self.maintainer_user)
+
+        self.assertTrue(changed)
+        machine = report.machine
+        self.assertEqual(machine.operational_status, OperationalStatus.BROKEN)
+        self.assertEqual(machine.updated_by, self.maintainer_user)
+        auto_log = LogEntry.objects.filter(machine=machine, text__startswith="Status changed")
+        self.assertTrue(auto_log.exists())
+        self.assertEqual(auto_log.first().created_by, self.maintainer_user)
+
+
+@tag("models")
+class MachineStatusDowngradePromptTests(TestDataMixin, TestCase):
+    """`machine_status_downgrade_prompt` offers a return-to-service only when apt."""
+
+    def setUp(self):
+        super().setUp()
+        self.machine = create_machine(operational_status=OperationalStatus.BROKEN)
+
+    def _closed_unplayable(self):
+        return create_problem_report(
+            machine=self.machine, status=Status.CLOSED, priority=Priority.UNPLAYABLE
+        )
+
+    def test_prompt_after_last_unplayable_closed(self):
+        create_problem_report(machine=self.machine, status=Status.OPEN, priority=Priority.MINOR)
+        create_problem_report(machine=self.machine, status=Status.OPEN, priority=Priority.MINOR)
+        create_problem_report(machine=self.machine, status=Status.OPEN, priority=Priority.MAJOR)
+        closed = self._closed_unplayable()
+
+        prompt = machine_status_downgrade_prompt(closed)
+
+        self.assertIsNotNone(prompt)
+        self.assertEqual(prompt["remaining_open"], 3)
+        self.assertEqual(prompt["machine_slug"], self.machine.slug)
+        # Breakdown is ordered by Priority enum position (Major before Minor).
+        self.assertEqual(
+            prompt["breakdown"],
+            [
+                {"priority": Priority.MAJOR, "label": "Major", "count": 1},
+                {"priority": Priority.MINOR, "label": "Minor", "count": 2},
+            ],
+        )
+        self.assertIn("Set machine to Good?", prompt["message"])
+        self.assertIn("1 Major", prompt["message"])
+        self.assertIn("2 Minor", prompt["message"])
+
+    def test_prompt_message_when_no_reports_remain(self):
+        closed = self._closed_unplayable()
+
+        prompt = machine_status_downgrade_prompt(closed)
+
+        self.assertIsNotNone(prompt)
+        self.assertEqual(prompt["remaining_open"], 0)
+        self.assertEqual(prompt["breakdown"], [])
+        self.assertIn("No open reports remain", prompt["message"])
+
+    def test_none_when_other_unplayable_still_open(self):
+        create_problem_report(
+            machine=self.machine, status=Status.OPEN, priority=Priority.UNPLAYABLE
+        )
+        closed = self._closed_unplayable()
+
+        self.assertIsNone(machine_status_downgrade_prompt(closed))
+
+    def test_none_when_machine_not_broken(self):
+        good_machine = create_machine(operational_status=OperationalStatus.GOOD)
+        closed = create_problem_report(
+            machine=good_machine, status=Status.CLOSED, priority=Priority.UNPLAYABLE
+        )
+
+        self.assertIsNone(machine_status_downgrade_prompt(closed))
+
+    def test_none_when_closed_report_not_unplayable(self):
+        closed = create_problem_report(
+            machine=self.machine, status=Status.CLOSED, priority=Priority.MAJOR
+        )
+
+        self.assertIsNone(machine_status_downgrade_prompt(closed))
+
+    def test_none_when_report_still_open(self):
+        still_open = create_problem_report(
+            machine=self.machine, status=Status.OPEN, priority=Priority.UNPLAYABLE
+        )
+
+        self.assertIsNone(machine_status_downgrade_prompt(still_open))
+
+
+@tag("models")
+class ReconcileUnplayableMachineStatusTests(TestDataMixin, TestCase):
+    """The one-time backfill fixes drift one-directionally and documents it."""
+
+    @staticmethod
+    def _run():
+        return reconcile_unplayable_machine_status(apps, log=lambda message: None)
+
+    def test_marks_drifted_machine_broken_and_logs_cleanup(self):
+        create_problem_report(
+            machine=self.machine, status=Status.OPEN, priority=Priority.UNPLAYABLE
+        )
+
+        result = self._run()
+
+        self.assertEqual(result["updated"], 1)
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, OperationalStatus.BROKEN)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                machine=self.machine, text__icontains="automated cleanup"
+            ).exists()
+        )
+
+    def test_skips_machine_already_broken(self):
+        machine = create_machine(operational_status=OperationalStatus.BROKEN)
+        create_problem_report(machine=machine, status=Status.OPEN, priority=Priority.UNPLAYABLE)
+
+        result = self._run()
+
+        self.assertEqual(result["updated"], 0)
+        self.assertFalse(
+            LogEntry.objects.filter(machine=machine, text__icontains="automated cleanup").exists()
+        )
+
+    def test_skips_machine_without_open_unplayable(self):
+        # A closed unplayable report and an open non-unplayable report both leave
+        # the machine untouched.
+        create_problem_report(
+            machine=self.machine, status=Status.CLOSED, priority=Priority.UNPLAYABLE
+        )
+        create_problem_report(machine=self.machine, status=Status.OPEN, priority=Priority.MINOR)
+
+        result = self._run()
+
+        self.assertEqual(result["updated"], 0)
+        self.machine.refresh_from_db()
+        self.assertEqual(self.machine.operational_status, OperationalStatus.GOOD)
+
+    def test_does_not_unbreak_machine_without_reports(self):
+        machine = create_machine(operational_status=OperationalStatus.BROKEN)
+
+        result = self._run()
+
+        self.assertEqual(result["updated"], 0)
+        machine.refresh_from_db()
+        self.assertEqual(machine.operational_status, OperationalStatus.BROKEN)

--- a/flipfix/apps/maintenance/views/problem_reports.py
+++ b/flipfix/apps/maintenance/views/problem_reports.py
@@ -49,6 +49,10 @@ from flipfix.apps.maintenance.models import (
     ProblemReport,
     ProblemReportMedia,
 )
+from flipfix.apps.maintenance.status_rules import (
+    enforce_unplayable_breaks_machine,
+    machine_status_downgrade_prompt,
+)
 
 
 class ProblemReportListView(TemplateView):
@@ -235,6 +239,9 @@ class ProblemReportCreateView(FormPrefillMixin, SharedAccountMixin, FormView):
         report.save()
         sync_references(report, report.description)
 
+        # An open Unplayable report means the machine is broken.
+        enforce_unplayable_breaks_machine(report, actor=self.request.user)
+
         # Handle media uploads
         media_files = form.cleaned_data.get("media_file", [])
         if media_files:
@@ -385,14 +392,20 @@ class ProblemReportDetailView(InlineTextEditMixin, MediaUploadMixin, DetailView)
             return JsonResponse({"success": False, "error": "Invalid priority"}, status=400)
         if new_priority == self.object.priority:
             return JsonResponse({"success": True, "status": "noop"})
-        self.object.priority = new_priority
-        self.object.save(update_fields=["priority", "updated_at"])
+        with transaction.atomic():
+            self.object.priority = new_priority
+            self.object.save(update_fields=["priority", "updated_at"])
+            # Raising priority to Unplayable breaks the machine.
+            machine_marked_broken = enforce_unplayable_breaks_machine(
+                self.object, actor=request.user
+            )
         return JsonResponse(
             {
                 "success": True,
                 "status": "success",
                 "priority": new_priority,
                 "priority_display": self.object.get_priority_display(),
+                "machine_marked_broken": machine_marked_broken,
             }
         )
 
@@ -411,16 +424,18 @@ class ProblemReportDetailView(InlineTextEditMixin, MediaUploadMixin, DetailView)
             {"entry": log_entry},
             request=request,
         )
-        return JsonResponse(
-            {
-                "success": True,
-                "status": "success",
-                "new_status": new_status,
-                "new_status_display": self.object.get_status_display(),
-                "log_entry_html": log_entry_html,
-                "entry_type": "log",
-            }
-        )
+        response = {
+            "success": True,
+            "status": "success",
+            "new_status": new_status,
+            "new_status_display": self.object.get_status_display(),
+            "log_entry_html": log_entry_html,
+            "entry_type": "log",
+        }
+        prompt = machine_status_downgrade_prompt(self.object)
+        if prompt is not None:
+            response["machine_status_prompt"] = prompt
+        return JsonResponse(response)
 
     def _handle_toggle_status(self, request):
         """Form POST: toggle between open/closed (desktop Close/Re-Open button)."""
@@ -441,6 +456,18 @@ class ProblemReportDetailView(InlineTextEditMixin, MediaUploadMixin, DetailView)
                 action_text,
             ),
         )
+        prompt = machine_status_downgrade_prompt(self.object)
+        if prompt is not None:
+            machine = self.object.machine
+            messages.info(
+                request,
+                format_html(
+                    '{} <a href="{}">Update {} status</a>.',
+                    prompt["message"],
+                    reverse("machine-details", kwargs={"slug": machine.slug}),
+                    machine.short_display_name,
+                ),
+            )
         return redirect("problem-report-detail", pk=self.object.pk)
 
     def _change_report_status(self, new_status, user):

--- a/templates/components/machine_sidebar_card.html
+++ b/templates/components/machine_sidebar_card.html
@@ -7,7 +7,8 @@
   <div class="sidebar-card__header">{{ machine.name }}</div>
   <p class="sidebar-card__meta">{{ machine.model|manufacturer_year }}</p>
   <div class="sidebar-card__badges">
-    <span class="pill {{ machine.operational_status|machine_status_css_class }}">
+    <span class="pill {{ machine.operational_status|machine_status_css_class }}"
+          data-machine-status-pill>
       {% icon machine.operational_status|machine_status_icon class="meta" %}
       {{ machine.get_operational_status_display }}
     </span>

--- a/templates/maintenance/problem_report_detail.html
+++ b/templates/maintenance/problem_report_detail.html
@@ -159,6 +159,10 @@
           if (!container) {
             container = document.createElement('div');
             container.className = 'messages';
+            // Match the server-rendered container (base.html) so screen readers
+            // announce the prompt.
+            container.setAttribute('role', 'alert');
+            container.setAttribute('aria-live', 'polite');
             (document.querySelector('.main-content') || document.body).prepend(container);
           }
           const msg = document.createElement('div');

--- a/templates/maintenance/problem_report_detail.html
+++ b/templates/maintenance/problem_report_detail.html
@@ -18,7 +18,8 @@
   <div class="mobile-meta"
        data-update-url="{% url 'problem-report-detail' report.pk %}"
        data-report-pk="{{ report.pk }}"
-       data-machine-name="{{ machine.short_display_name }}">
+       data-machine-name="{{ machine.short_display_name }}"
+       data-machine-update-url="{% url 'machine-inline-update' machine.slug %}">
     {# Settable status and priority pills #}
     <div class="mobile-meta__row">
       {% settable_problem_status_pill report %}
@@ -40,7 +41,8 @@
   <div class="flex flex-wrap stack-tight space-above-sm"
        data-update-url="{% url 'problem-report-detail' report.pk %}"
        data-report-pk="{{ report.pk }}"
-       data-machine-name="{{ machine.short_display_name }}">
+       data-machine-name="{{ machine.short_display_name }}"
+       data-machine-update-url="{% url 'machine-inline-update' machine.slug %}">
     {% settable_problem_status_pill report %}
     {% settable_problem_priority_pill report %}
     {% problem_report_type_pill report %}
@@ -129,34 +131,105 @@
     <script src="{% static 'core/searchable_dropdown.js' %}" defer></script>
     <script src="{% static 'core/sidebar_card_edit.js' %}" defer></script>
     <script>
-      // Problem report side effects: Close/Re-Open button toggle, toasts
-      document.addEventListener('pill:updated', (event) => {
-        const { field, value, label, data } = event.detail;
-        const wrapper = event.target.closest('[data-update-url]') || event.target;
-        const updateUrl = wrapper.dataset.updateUrl;
-        const reportPk = wrapper.dataset.reportPk;
-        const machineName = escapeHtml(wrapper.dataset.machineName || '');
+      // Problem report side effects: Close/Re-Open toggle, toasts, and the
+      // machine-status coupling (Unplayable -> Broken, and the prompt back to Good).
+      (function () {
+        'use strict';
 
-        if (field === 'status') {
-          const isOpen = value === 'open';
-          const closeBtn = document.querySelector('[data-status-action="close"]');
-          const reopenBtn = document.querySelector('[data-status-action="reopen"]');
-          if (closeBtn) closeBtn.classList.toggle('hidden', !isOpen);
-          if (reopenBtn) reopenBtn.classList.toggle('hidden', isOpen);
-          showMessage(
-            'success',
-            `<a href="${updateUrl}">Problem #${reportPk}</a> on ${machineName} ${isOpen ? 're-opened' : 'closed'}`
-          );
-        } else if (field === 'priority') {
-          const { pillClass, iconClass } = readPillStyling('priority');
-          const iconHtml = iconClass ? `<i class="fa-solid ${iconClass} meta"></i> ` : '';
-          const pillHtml = `<span class="pill ${pillClass}">${iconHtml}${escapeHtml(label)}</span>`;
-          showMessage(
-            'success',
-            `<a href="${updateUrl}">Problem #${reportPk}</a> on ${machineName} set to ${pillHtml}`
-          );
+        const MACHINE_STATUS_STYLES = {
+          good: { pill: 'pill--status-good', icon: 'check', label: 'Good' },
+          fixing: { pill: 'pill--status-fixing', icon: 'wrench', label: 'Fixing' },
+          broken: { pill: 'pill--status-broken', icon: 'circle-xmark', label: 'Broken' },
+        };
+
+        // Update the static machine status pill in the sidebar card in place.
+        function setMachineStatusPill(status) {
+          const style = MACHINE_STATUS_STYLES[status];
+          const pill = document.querySelector('[data-machine-status-pill]');
+          if (!pill || !style) return;
+          pill.className = `pill ${style.pill}`;
+          pill.innerHTML = `<i class="fa-solid fa-${style.icon} meta" aria-hidden="true"></i> ${style.label}`;
         }
-      });
+
+        // After the last open Unplayable report is closed, offer to return the
+        // machine to service (one-click POST to the machine status endpoint).
+        function renderMachineGoodPrompt(prompt, machineUpdateUrl) {
+          if (!machineUpdateUrl) return;
+          let container = document.querySelector('.messages');
+          if (!container) {
+            container = document.createElement('div');
+            container.className = 'messages';
+            (document.querySelector('.main-content') || document.body).prepend(container);
+          }
+          const msg = document.createElement('div');
+          msg.className = 'message message--info';
+          msg.innerHTML =
+            `<span>${escapeHtml(prompt.message)}</span> ` +
+            '<button type="button" class="btn btn--status-good btn--sm" data-set-machine-good>Set machine to Good</button>';
+          const button = msg.querySelector('[data-set-machine-good]');
+          button.addEventListener('click', () => {
+            button.disabled = true;
+            const body = new FormData();
+            body.append('action', 'update_status');
+            body.append('operational_status', 'good');
+            fetch(machineUpdateUrl, {
+              method: 'POST',
+              body,
+              credentials: 'same-origin',
+              headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-CSRFToken': getCsrfToken() },
+            })
+              .then((res) => {
+                if (!res.ok) throw new Error('Request failed');
+                return res.json();
+              })
+              .then(() => {
+                setMachineStatusPill('good');
+                msg.remove();
+                showMessage('success', 'Machine set to Good.');
+              })
+              .catch(() => {
+                button.disabled = false;
+                showMessage('error', 'Could not update machine status.');
+              });
+          });
+          container.appendChild(msg);
+        }
+
+        document.addEventListener('pill:updated', (event) => {
+          const { field, value, label, data } = event.detail;
+          const wrapper = event.target.closest('[data-update-url]') || event.target;
+          const updateUrl = wrapper.dataset.updateUrl;
+          const reportPk = wrapper.dataset.reportPk;
+          const machineName = escapeHtml(wrapper.dataset.machineName || '');
+
+          if (field === 'status') {
+            const isOpen = value === 'open';
+            const closeBtn = document.querySelector('[data-status-action="close"]');
+            const reopenBtn = document.querySelector('[data-status-action="reopen"]');
+            if (closeBtn) closeBtn.classList.toggle('hidden', !isOpen);
+            if (reopenBtn) reopenBtn.classList.toggle('hidden', isOpen);
+            showMessage(
+              'success',
+              `<a href="${updateUrl}">Problem #${reportPk}</a> on ${machineName} ${isOpen ? 're-opened' : 'closed'}`
+            );
+            if (data && data.machine_status_prompt) {
+              renderMachineGoodPrompt(data.machine_status_prompt, wrapper.dataset.machineUpdateUrl);
+            }
+          } else if (field === 'priority') {
+            const { pillClass, iconClass } = readPillStyling('priority');
+            const iconHtml = iconClass ? `<i class="fa-solid ${iconClass} meta"></i> ` : '';
+            const pillHtml = `<span class="pill ${pillClass}">${iconHtml}${escapeHtml(label)}</span>`;
+            showMessage(
+              'success',
+              `<a href="${updateUrl}">Problem #${reportPk}</a> on ${machineName} set to ${pillHtml}`
+            );
+            if (data && data.machine_marked_broken) {
+              setMachineStatusPill('broken');
+              showMessage('info', `${machineName} marked Broken to match the Unplayable report.`);
+            }
+          }
+        });
+      })();
     </script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

Overlap between a machine's overall state (Good/Fixing/Broken/Unknown) and its problem list is now a real invariant: **an open `Unplayable` problem report means the machine is `Broken`.**

- **Forward rule (automatic, one-directional):** creating a report as `Unplayable`, or re-prioritising one to `Unplayable`, marks its machine `Broken` (if not already). Enforced at every write path — the maintainer create view, the priority-update endpoint, and the write API. Never auto-un-breaks (a machine can be broken for other reasons).
- **Back to service (human-in-the-loop):** closing the **last** open `Unplayable` report on a `Broken` machine surfaces a "Set machine to Good?" prompt summarising the reports that remain — one-click on the detail page, an info message on the desktop form-POST path. Nothing changes silently.
- **One-time migration** reconciles pre-existing drift (open `Unplayable` but not `Broken` → `Broken`), logging each fix to the machine's timeline.

## Design

- The rule is centralised in `maintenance/status_rules.py` and called explicitly at each write site (rather than a `save()` override or a signal) so the acting user can be threaded through — the existing `MachineInstance` post_save signal then attributes the auto "Status changed → Broken" log entry correctly.
- The `mark_broken` API flag is retained (it still lets `juice` mark non-Unplayable reports broken); the new rule composes with it idempotently, and the Unplayable idempotency branch now repairs drift too.
- The backfill lives in `maintenance/reconcile_machine_status.py` as an `apps`-registry function shared by the migration and its unit test — the same split used by `deduplication.py`.
- Front-end reuses the existing `settable_pill.js` / `pill:updated` event system and the `machine-inline-update` endpoint; no new AJAX machinery.

## Files

- **New:** `status_rules.py`, `reconcile_machine_status.py`, `migrations/0024_reconcile_unplayable_machine_status.py`, `tests/test_status_rules.py`
- **Changed:** `maintenance/views/problem_reports.py`, `core/views/api.py`, `templates/maintenance/problem_report_detail.html`, `templates/components/machine_sidebar_card.html`, `docs/Datamodel.md`, `docs/Models.md`, plus API/create/detail test extensions

## Testing

- New + affected server tests pass; view tests drive the real endpoints end-to-end (create, priority-update, close, write API).
- Full fast suite: **1988 tests OK**. `make lint`, `make typecheck` (400 files clean), `make test-js` (221) all green. Migration applies cleanly (test DB builds through 0024) and `makemigrations --check` passes.

## Note / possible fast-follow

The auto-broken rule and the "back to Good?" prompt are scoped as requested (Unplayable → Broken; prompt on **close**). A priority *downgrade* away from Unplayable doesn't yet trigger the same prompt — reasonable to add later for full symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Open “Unplayable” problem reports now automatically mark the associated machine as **Broken**.
  - Raising a report’s priority to “Unplayable” applies the same machine-status update.
  - Closing the last open “Unplayable” report displays a prompt to consider returning the machine to **Good**.
  - Machine status updates are reflected immediately in the problem report interface.

- **Bug Fixes**
  - Existing machine-status inconsistencies are corrected automatically for machines with open “Unplayable” reports.

- **Documentation**
  - Clarified the relationship between problem reports and machine operational status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->