### PR TITLE
chore(deps): bump Django, Pillow, pillow-heif for security advisories

### DIFF
--- a/requirements.native.txt
+++ b/requirements.native.txt
@@ -7,5 +7,5 @@
 # - audioop-lts: Python 3.13 compatibility shim for discord.py voice.
 #   Only needed on Python >= 3.13 (audioop was removed from stdlib).
 
-pillow-heif==1.2.0
+pillow-heif==1.4.0
 audioop-lts==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Django Web Framework
-Django==5.2.15
+Django==5.2.16
 
 # Configuration Management
 python-decouple==3.8
@@ -17,7 +17,7 @@ whitenoise==6.11.0
 
 # QR Code Generation
 qrcode[pil]==8.2
-Pillow==12.2.0
+Pillow==12.3.0
 django-q2==1.9.0
 
 # HTTP Requests (for worker → web service transfer)


### PR DESCRIPTION
## Summary

The CI **"Audit dependencies for vulnerabilities"** step (`pip-audit`) is currently red on every PR — it flagged 9 advisories across three packages and, because it runs before the test steps and exits non-zero, it also **skips the Postgres test run**. This bumps the affected pins to restore a green pipeline.

| Package | Was | Now | Advisories fixed |
|---|---|---|---|
| Django | 5.2.15 | **5.2.16** | PYSEC-2026-2090/2091/2092 |
| Pillow | 12.2.0 | **12.3.0** | PYSEC-2026-2253/2254/2255/2256/2257 |
| pillow-heif | 1.2.0 | **1.4.0** | PYSEC-2026-2258 |

## Why only these three

`pip-audit` scans the whole installed environment, but only these three are the ones it flagged — because they're **exact-pinned** (`==`) in the requirements files and therefore stay frozen at vulnerable versions. The floating transitive dependencies re-resolve to patched versions on each fresh CI install, so they don't need pinning here.

## Notes

- **Django stays on the 5.2 LTS line.** Latest overall is 6.0.7, but a major bump is out of scope for a security patch and warrants its own compatibility review.
- `pillow-heif==1.4.0` is the latest stable and requires `pillow>=11.1.0`, satisfied by 12.3.0.
- Full fast suite (**1988 tests**) passes locally on the bumped versions; HEIF opener import verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)