### PR TITLE
feat(dev): sync sanitized production data into local Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,20 @@ SECRET_KEY=change-me
 
 ALLOWED_HOSTS=localhost,127.0.0.1
 
+# Database
+# -------
+# Dev uses SQLite by default (leave DATABASE_URL unset). To match production's
+# engine and to use `make sync-prod`, start the local Postgres (`make db-up`)
+# and uncomment DATABASE_URL below. If port 54321 clashes, change it here AND in
+# docker-compose.yml.
+# DATABASE_URL=postgres://flipfix:flipfix@localhost:54321/flipfix
+
+# Source for `make sync-prod` (maintainers only). Paste Railway's PUBLIC Postgres
+# URL: Railway -> flip-fix -> Postgres -> Variables -> DATABASE_PUBLIC_URL. Do NOT
+# use the *.railway.internal host — it is unreachable from your machine. The sync
+# only ever reads production. Leave blank if you don't sync prod data.
+PROD_DATABASE_URL=
+
 # Video Transcoding HTTP Transfer (required for video transcoding to work)
 # The worker process (qcluster) POSTs transcoded files to the Django web server via HTTP.
 #

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,15 @@
     }
   ],
   "results": {
+    ".env.example": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "46b77a488d3213a27e9f9f18090f7adc04e4672b",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
     ".github/workflows/ci.yml": [
       {
         "type": "Secret Keyword",
@@ -141,6 +150,15 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
         "line_number": 109
+      }
+    ],
+    "docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "46b77a488d3213a27e9f9f18090f7adc04e4672b",
+        "is_verified": false,
+        "line_number": 19
       }
     ],
     "flipfix/apps/accounts/tests/test_profile.py": [
@@ -169,5 +187,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-18T23:08:48Z"
+  "generated_at": "2026-07-16T02:36:42Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,15 @@ make migrate        # Run migrations
 make migrations     # Create new migrations
 make superuser      # Create superuser
 make sample-data    # Create sample data (dev only)
+make db-up          # Start local Postgres (docker compose); dev uses SQLite unless DATABASE_URL is set
+make sync-prod      # Refresh local DB with sanitized production data (needs Docker + PROD_DATABASE_URL)
 ```
+
+Dev defaults to SQLite. Set `DATABASE_URL` in `.env` (see `.env.example`) to run
+dev on the local Postgres from `docker-compose.yml` — this matches production's
+engine and is required for `make sync-prod`. See
+[`docs/Operations.md`](Operations.md) for the prod-sync workflow (what it scrubs
+and excludes; media is not synced).
 
 Run a single test:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,15 @@ make migrate        # Run migrations
 make migrations     # Create new migrations
 make superuser      # Create superuser
 make sample-data    # Create sample data (dev only)
+make db-up          # Start local Postgres (docker compose); dev uses SQLite unless DATABASE_URL is set
+make sync-prod      # Refresh local DB with sanitized production data (needs Docker + PROD_DATABASE_URL)
 ```
+
+Dev defaults to SQLite. Set `DATABASE_URL` in `.env` (see `.env.example`) to run
+dev on the local Postgres from `docker-compose.yml` — this matches production's
+engine and is required for `make sync-prod`. See
+[`docs/Operations.md`](Operations.md) for the prod-sync workflow (what it scrubs
+and excludes; media is not synced).
 
 Run a single test:
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ help:
 	@echo "  make superuser      - Create superuser"
 	@echo "  make sample-data    - Create sample data (dev only)"
 	@echo "  make pull-sample-machines - Refresh machines.json fixture from prod API (needs SAMPLE_DATA_API_KEY)"
+	@echo "  make db-up          - Start the local Postgres container (docker compose)"
+	@echo "  make db-down        - Stop the local Postgres container (keeps data)"
+	@echo "  make db-reset       - Stop the local Postgres container and DELETE its data"
+	@echo "  make sync-prod      - Refresh local DB with sanitized production data (needs PROD_DATABASE_URL)"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  make agent-docs     - Regenerate CLAUDE.md and AGENTS.md from source"
@@ -114,6 +118,22 @@ sample-data:
 .PHONY: pull-sample-machines
 pull-sample-machines:
 	$(PYTHON) manage.py pull_sample_machines
+
+.PHONY: db-up
+db-up:
+	docker compose up -d db
+
+.PHONY: db-down
+db-down:
+	docker compose down
+
+.PHONY: db-reset
+db-reset:
+	docker compose down -v
+
+.PHONY: sync-prod
+sync-prod:
+	scripts/sync_prod.sh
 
 .PHONY: lint
 lint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+# Local Postgres for development, to mirror production (which runs Postgres on
+# Railway) and to back the `make sync-prod` workflow. Dev defaults to SQLite; set
+# DATABASE_URL in .env to opt into this database (see .env.example).
+#
+# Running pg_dump/psql *inside* this container (as scripts/sync_prod.sh does)
+# guarantees the client version is >= the prod server version, which pg_dump
+# requires. Pin `image` to at least prod's Postgres major version — verify with:
+#   psql "$PROD_DATABASE_URL" -tAc 'show server_version'
+services:
+  db:
+    image: postgres:18
+    # 54321 (mnemonic 5-4-3-2-1) instead of the default 5432 to avoid clashing
+    # with any other Postgres already running locally. If 54321 is also taken,
+    # change both this and the DATABASE_URL port in your .env (e.g. 54322).
+    ports:
+      - "54321:5432"
+    environment:
+      POSTGRES_USER: flipfix
+      POSTGRES_PASSWORD: flipfix
+      POSTGRES_DB: flipfix
+    volumes:
+      # Postgres 18+ stores data in a version subdirectory and wants the volume
+      # mounted at /var/lib/postgresql (not /var/lib/postgresql/data, the pre-18
+      # convention). See https://github.com/docker-library/postgres/pull/1259
+      - flipfix_pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U flipfix -d flipfix"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  flipfix_pgdata:

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -155,7 +155,15 @@ make migrate        # Run migrations
 make migrations     # Create new migrations
 make superuser      # Create superuser
 make sample-data    # Create sample data (dev only)
+make db-up          # Start local Postgres (docker compose); dev uses SQLite unless DATABASE_URL is set
+make sync-prod      # Refresh local DB with sanitized production data (needs Docker + PROD_DATABASE_URL)
 ```
+
+Dev defaults to SQLite. Set `DATABASE_URL` in `.env` (see `.env.example`) to run
+dev on the local Postgres from `docker-compose.yml` — this matches production's
+engine and is required for `make sync-prod`. See
+[`docs/Operations.md`](Operations.md) for the prod-sync workflow (what it scrubs
+and excludes; media is not synced).
 
 Run a single test:
 

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -71,6 +71,51 @@ Railway automatically backs up the PostgreSQL database daily.
 3. Select backup
 4. Click restore (point and click)
 
+### Sync production data into local dev
+
+To develop against realistic data, refresh a local Postgres database with a
+**sanitized** copy of production. This dumps prod read-only, restores into a
+local container, and scrubs all PII and secrets.
+
+**One-time setup:**
+
+1. Install Docker.
+2. Get the production Postgres **public** URL: Railway → `flip-fix` → the
+   `Postgres` service → Variables → `DATABASE_PUBLIC_URL`. (The
+   `*.railway.internal` host is unreachable from your machine.)
+3. In `.env`, set `PROD_DATABASE_URL=<that public URL>` and uncomment the
+   `DATABASE_URL` line (it points at the local Postgres from
+   `docker-compose.yml`; see `.env.example`). With `DATABASE_URL` set, dev runs
+   on Postgres instead of SQLite.
+4. Confirm the local Postgres major version is ≥ prod's — verify prod's with
+   `psql "$PROD_DATABASE_URL" -tAc 'show server_version'` and, if needed, bump
+   the `image:` in `docker-compose.yml`.
+
+**Each refresh:**
+
+```bash
+make db-up      # start the local Postgres container (first run only per boot)
+make sync-prod  # dump prod (read-only) → restore locally → scrub PII
+```
+
+Then log in at <http://localhost:8000/admin/> as `admin` / `admin` (the sync
+creates/refreshes this dev superuser; override with `DEV_SUPERUSER` /
+`DEV_PASSWORD`).
+
+**What the sync does and does not include:**
+
+- **Scope:** the "maintenance core" — machines, models, locations, owners
+  (contact details scrubbed), problem reports (reporter/IP/device scrubbed),
+  log entries, maintenance tasks, and users/maintainers (emails faked, passwords
+  made unusable). Parts, wiki, comments, and Discord links are emptied.
+- **Never copied:** OAuth tokens, `constance` secrets (Discord/Anthropic keys,
+  webhook URL), API keys, invitations, sessions, background-job payloads, and the
+  `simple_history` audit tables — excluded at dump time so they never touch disk.
+- **Media files are not synced** — image/video thumbnails will be broken links.
+- **Production is only ever read** (the dump session is forced read-only).
+
+`make db-down` stops the container (keeps data); `make db-reset` deletes it.
+
 ## File Storage
 
 ### Photo & Video Storage

--- a/flipfix/apps/accounts/management/commands/create_sample_accounts.py
+++ b/flipfix/apps/accounts/management/commands/create_sample_accounts.py
@@ -3,9 +3,9 @@
 import json
 from pathlib import Path
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 
 from flipfix.apps.accounts.models import Maintainer
 
@@ -16,10 +16,10 @@ class Command(BaseCommand):
     data_path = Path("docs/sample_data/records/accounts.json")
 
     def handle(self, *args: object, **options: object) -> None:
-        # Safety check: SQLite only (blocks production PostgreSQL)
-        if "sqlite" not in connection.settings_dict["ENGINE"].lower():
+        # Safety check: never populate the real production/staging database.
+        if not settings.ALLOW_SAMPLE_DATA:
             raise CommandError(
-                "This command only runs on SQLite databases (local dev or PR environments)"
+                "Sample data commands are disabled in this environment (production/staging)."
             )
 
         user_model = get_user_model()

--- a/flipfix/apps/catalog/management/commands/create_sample_machines.py
+++ b/flipfix/apps/catalog/management/commands/create_sample_machines.py
@@ -4,8 +4,8 @@ import json
 from decimal import Decimal
 from pathlib import Path
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 
 from flipfix.apps.catalog.models import Location, MachineInstance, MachineModel
 
@@ -16,10 +16,10 @@ class Command(BaseCommand):
     data_path = Path("docs/sample_data/records/machines.json")
 
     def handle(self, *args: object, **options: object) -> None:
-        # Safety check: SQLite only (blocks production PostgreSQL)
-        if "sqlite" not in connection.settings_dict["ENGINE"].lower():
+        # Safety check: never populate the real production/staging database.
+        if not settings.ALLOW_SAMPLE_DATA:
             raise CommandError(
-                "This command only runs on SQLite databases (local dev or PR environments)"
+                "Sample data commands are disabled in this environment (production/staging)."
             )
 
         # Safety check: empty database only

--- a/flipfix/apps/core/management/commands/create_sample_data.py
+++ b/flipfix/apps/core/management/commands/create_sample_data.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 
 
 class Command(BaseCommand):
     help = "Create all sample data (dev/PR environments only, not prod)."
 
     def handle(self, *args: object, **options: object) -> None:
-        # Safety check: SQLite only (blocks production PostgreSQL)
-        if "sqlite" not in connection.settings_dict["ENGINE"].lower():
+        # Safety check: never populate the real production/staging database.
+        if not settings.ALLOW_SAMPLE_DATA:
             raise CommandError(
-                "This command only runs on SQLite databases (local dev or PR environments)"
+                "Sample data commands are disabled in this environment (production/staging)."
             )
 
         self.stdout.write(self.style.SUCCESS("Creating sample data..."))

--- a/flipfix/apps/core/management/commands/create_sample_infinite_scrolling_data.py
+++ b/flipfix/apps/core/management/commands/create_sample_infinite_scrolling_data.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import secrets
 from datetime import timedelta
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 from django.utils import timezone
 
 from flipfix.apps.catalog.models import MachineInstance
@@ -54,10 +54,10 @@ class Command(BaseCommand):
     RECORDS_PER_TYPE = 25
 
     def handle(self, *args: object, **options: object) -> None:
-        # Safety check: SQLite only (blocks production PostgreSQL)
-        if "sqlite" not in connection.settings_dict["ENGINE"].lower():
+        # Safety check: never populate the real production/staging database.
+        if not settings.ALLOW_SAMPLE_DATA:
             raise CommandError(
-                "This command only runs on SQLite databases (local dev or PR environments)"
+                "Sample data commands are disabled in this environment (production/staging)."
             )
 
         self.stdout.write(self.style.SUCCESS("\nGenerating records to test infinite scrolling..."))

--- a/flipfix/apps/maintenance/management/commands/create_sample_logs_problems.py
+++ b/flipfix/apps/maintenance/management/commands/create_sample_logs_problems.py
@@ -8,9 +8,9 @@ import re
 from datetime import datetime
 from pathlib import Path
 
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 from django.utils import timezone
 
 from flipfix.apps.accounts.models import Maintainer
@@ -37,10 +37,10 @@ class Command(BaseCommand):
         }
 
     def handle(self, *args: object, **options: object) -> None:
-        # Safety check: SQLite only (blocks production PostgreSQL)
-        if "sqlite" not in connection.settings_dict["ENGINE"].lower():
+        # Safety check: never populate the real production/staging database.
+        if not settings.ALLOW_SAMPLE_DATA:
             raise CommandError(
-                "This command only runs on SQLite databases (local dev or PR environments)"
+                "Sample data commands are disabled in this environment (production/staging)."
             )
 
         # Safety check: empty database only

--- a/flipfix/apps/parts/management/commands/create_sample_parts.py
+++ b/flipfix/apps/parts/management/commands/create_sample_parts.py
@@ -8,9 +8,9 @@ import re
 from datetime import datetime
 from pathlib import Path
 
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
 from django.utils import timezone
 
 from flipfix.apps.accounts.models import Maintainer
@@ -37,10 +37,10 @@ class Command(BaseCommand):
         }
 
     def handle(self, *args: object, **options: object) -> None:
-        # Safety check: SQLite only (blocks production PostgreSQL)
-        if "sqlite" not in connection.settings_dict["ENGINE"].lower():
+        # Safety check: never populate the real production/staging database.
+        if not settings.ALLOW_SAMPLE_DATA:
             raise CommandError(
-                "This command only runs on SQLite databases (local dev or PR environments)"
+                "Sample data commands are disabled in this environment (production/staging)."
             )
 
         # Safety check: empty database only

--- a/flipfix/settings/base.py
+++ b/flipfix/settings/base.py
@@ -86,6 +86,12 @@ DATABASES = {
     }
 }
 
+# Whether sample-data management commands are allowed to run. True for dev, test,
+# and PR environments; production/staging set this False (see settings/prod_base).
+# The commands must never populate the real production database. This flag
+# replaces per-command engine checks so dev can run on Postgres.
+ALLOW_SAMPLE_DATA = True
+
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},

--- a/flipfix/settings/dev.py
+++ b/flipfix/settings/dev.py
@@ -4,12 +4,26 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import dj_database_url
+from decouple import config
+
 from .base import *  # noqa
 from .base import LOGGING as BASE_LOGGING
 
 LOGGING = deepcopy(BASE_LOGGING)
 
 DEBUG = True
+
+# Database: SQLite by default (zero-config), or Postgres when DATABASE_URL is set.
+# Read via python-decouple (environment, then .env) for consistency with the rest
+# of the settings — dj_database_url's own reader only checks os.environ, which the
+# project never populates from .env. Point DATABASE_URL at the local Postgres from
+# docker-compose.yml (see .env.example) to match production's engine and to
+# receive `make sync-prod` data.
+DATABASES["default"] = dj_database_url.parse(  # type: ignore[assignment]  # noqa: F405
+    config("DATABASE_URL", default=f"sqlite:///{REPO_ROOT / 'db.sqlite3'}"),  # noqa: F405
+    conn_max_age=600,
+)
 
 # Whitenoise for serving the app's static files (CSS, JS, etc)
 INSTALLED_APPS = ["whitenoise.runserver_nostatic", *INSTALLED_APPS]  # noqa: F405

--- a/flipfix/settings/prod_base.py
+++ b/flipfix/settings/prod_base.py
@@ -89,3 +89,8 @@ else:
             conn_health_checks=True,
         )
     }
+
+    # Real production/staging: never allow sample-data commands to run against
+    # this database. PR environments (the SQLite branch above) keep the base
+    # default of True so their seeded fixtures still work.
+    ALLOW_SAMPLE_DATA = False

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -194,3 +194,5 @@ DJANGO_SETTINGS_MODULE=flipfix.settings.dev "$VENV_DIR/bin/python" manage.py mig
 
 info ""
 info "Bootstrap complete! Run 'make runserver' to start developing."
+info "For realistic data, either 'make sample-data' (curated fixtures) or"
+info "'make db-up && make sync-prod' (sanitized production data; needs Docker + PROD_DATABASE_URL)."

--- a/scripts/sanitize_dev_db.sql
+++ b/scripts/sanitize_dev_db.sql
@@ -1,0 +1,78 @@
+-- Sanitize a freshly-restored production dump for safe local development use.
+--
+-- Run ONLY against the local dev database, never production. scripts/sync_prod.sh
+-- runs this automatically after restoring the dump into the local Postgres
+-- container. It is idempotent and safe to re-run.
+--
+-- Secret/history/out-of-scope table DATA is already excluded at dump time by
+-- sync_prod.sh, so the TRUNCATEs below are belt-and-suspenders: they also make
+-- this file correct if someone restores a full (un-excluded) dump. Missing
+-- tables are skipped rather than erroring, so the file tolerates schema drift.
+
+BEGIN;
+
+-- 1. Empty every table whose data must never exist in a dev environment:
+--    live secrets/credentials, sessions, background-job payloads, the
+--    django-simple-history shadow tables (which duplicate every past value of
+--    the PII scrubbed below), and the apps outside the "maintenance core" scope
+--    (parts / wiki / comments / documents / discord).
+-- Matched by table-name PATTERN rather than a hardcoded list, so new tables in a
+-- dropped app (or a renamed one, e.g. constance_constance vs constance_config)
+-- are covered automatically. Only whole apps that are entirely out of scope get a
+-- prefix wildcard; the kept "catalog"/"maintenance"/"auth" apps are never
+-- wildcarded — their few droppable tables are named explicitly. Every parent's
+-- children fall under the same wildcard (or are *historical*), so
+-- TRUNCATE ... CASCADE never reaches a kept core table.
+DO $$
+DECLARE
+    tbl text;
+BEGIN
+    FOR tbl IN
+        SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'public' AND (
+               table_name LIKE '%historical%'          -- simple_history shadow tables
+            OR table_name LIKE 'constance\_%'           -- dynamic settings (secrets)
+            OR table_name LIKE 'oauth2\_provider\_%'    -- OAuth tokens/apps
+            OR table_name LIKE 'oauth\_%'               -- app capability grants
+            OR table_name LIKE 'django\_q\_%'           -- background-job payloads
+            OR table_name LIKE 'parts\_%'               -- out-of-scope app
+            OR table_name LIKE 'wiki\_%'                -- out-of-scope app
+            OR table_name LIKE 'discord\_%'             -- out-of-scope app
+            OR table_name IN (
+                'core_apikey', 'accounts_invitation',
+                'django_session', 'django_admin_log',
+                'catalog_machinecomment', 'catalog_ownercomment',
+                'catalog_ownerdocument'
+            )
+        )
+    LOOP
+        EXECUTE format('TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE', tbl);
+    END LOOP;
+END $$;
+
+-- 2. Scrub PII from the kept "maintenance core" tables.
+
+-- Users: fake emails, drop names, mark passwords unusable. sync_prod.sh sets a
+-- known dev password on a superuser afterwards so you can still log in.
+UPDATE auth_user SET
+    email      = 'user' || id || '@example.test',
+    first_name = '',
+    last_name  = '',
+    password   = '!scrubbed';   -- '!' prefix = Django "unusable password"
+
+-- Machine owners: clear all direct contact details.
+UPDATE catalog_owner SET
+    email             = '',
+    phone             = '',
+    address           = '',
+    alternate_contact = '',
+    notes             = '';
+
+-- Visitor-submitted problem reports: clear reporter identity and request metadata.
+UPDATE maintenance_problemreport SET
+    reported_by_name    = '',
+    reported_by_contact = '',
+    device_info         = '',
+    ip_address          = NULL;
+
+COMMIT;

--- a/scripts/sync_prod.sh
+++ b/scripts/sync_prod.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Refresh the local dev database with (sanitized) production data.
+#
+#   make sync-prod            # or: scripts/sync_prod.sh [--yes]
+#
+# What it does:
+#   1. pg_dump production (READ-ONLY), excluding secret / history / out-of-scope
+#      table DATA so those rows never touch your disk.
+#   2. Drop & recreate your LOCAL Postgres database and restore the dump.
+#   3. Run scripts/sanitize_dev_db.sql to scrub residual PII.
+#   4. Run migrations (a no-op unless your branch has unapplied migrations).
+#   5. Create/refresh a dev superuser so you can log in (all prod passwords are
+#      scrubbed).
+#
+# Requirements:
+#   - Docker (the local Postgres from docker-compose.yml; started via `make db-up`).
+#   - PROD_DATABASE_URL in .env — Railway's *public* connection string
+#     (Postgres service -> Variables -> DATABASE_PUBLIC_URL). The internal
+#     *.railway.internal host is NOT reachable from your machine.
+#   - DATABASE_URL in .env pointing at the local container (see .env.example).
+#
+# Media files are NOT synced (thumbnails will be broken links locally).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Output helpers ---
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; NC=''
+fi
+info() { echo -e "${GREEN}[sync-prod]${NC} $*"; }
+warn() { echo -e "${YELLOW}[sync-prod]${NC} $*"; }
+fail() { echo -e "${RED}[sync-prod]${NC} $*" >&2; exit 1; }
+
+ASSUME_YES=false
+[ "${1:-}" = "--yes" ] && ASSUME_YES=true
+
+PYTHON="$(test -x .venv/bin/python && echo .venv/bin/python || echo python3)"
+
+# --- Read a variable from the environment, falling back to .env ---
+read_env_var() {
+  local name="$1" val="${!1:-}"
+  if [ -z "$val" ] && [ -f .env ]; then
+    # Last matching, uncommented assignment wins; strip surrounding quotes.
+    val="$(grep -E "^${name}=" .env | tail -1 | cut -d= -f2- | sed -e 's/^"//' -e "s/^'//" -e 's/"$//' -e "s/'$//")"
+  fi
+  printf '%s' "$val"
+}
+
+# --- Local Postgres connection (the docker-compose "db" service) ---
+LOCAL_URL="$(read_env_var DATABASE_URL)"
+LOCAL_URL="${LOCAL_URL:-postgres://flipfix:flipfix@localhost:54321/flipfix}"  # pragma: allowlist secret
+case "$LOCAL_URL" in
+  *localhost*|*127.0.0.1*) : ;;
+  *) fail "DATABASE_URL must point at your LOCAL Postgres (localhost). Got a non-local host — refusing to drop/overwrite it." ;;
+esac
+# Database name to restore into (last path segment of the URL).
+LOCAL_DB="$(printf '%s' "$LOCAL_URL" | sed -E 's#.*/([^/?]+).*#\1#')"
+
+# --- Production source (read-only) ---
+PROD_URL="$(read_env_var PROD_DATABASE_URL)"
+[ -n "$PROD_URL" ] || fail "PROD_DATABASE_URL is not set (env or .env). See .env.example."
+case "$PROD_URL" in
+  *railway.internal*) fail "PROD_DATABASE_URL is the internal Railway host, unreachable from your machine. Use DATABASE_PUBLIC_URL instead." ;;
+  postgres://*|postgresql://*) : ;;
+  *) fail "PROD_DATABASE_URL must be a postgres:// URL." ;;
+esac
+
+DC="docker compose"
+$DC version >/dev/null 2>&1 || fail "Docker Compose not available. Install Docker Desktop / the compose plugin."
+
+# --- Confirm (destructive) ---
+warn "This will DROP and rebuild your local database '${LOCAL_DB}' from production."
+warn "Production is read only; nothing there is modified. Local data is replaced."
+if [ "$ASSUME_YES" != true ]; then
+  read -r -p "Type 'yes' to continue: " reply
+  [ "$reply" = "yes" ] || fail "Aborted."
+fi
+
+# --- Ensure the local db container is up and accepting connections ---
+info "Starting local Postgres container..."
+$DC up -d db >/dev/null
+info "Waiting for Postgres to be ready..."
+for _ in $(seq 1 30); do
+  if $DC exec -T db pg_isready -U flipfix -d postgres >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+$DC exec -T db pg_isready -U flipfix -d postgres >/dev/null 2>&1 \
+  || fail "Local Postgres did not become ready."
+
+# --- Dump production (read-only), secrets/history/out-of-scope data excluded ---
+DUMP="$(mktemp "${TMPDIR:-/tmp}/flipfix-prod-dump.XXXXXX.sql")"
+cleanup() { rm -f "$DUMP"; }
+trap cleanup EXIT
+
+# --exclude-table-data keeps each table's DDL (so schema + django_migrations stay
+# consistent and `migrate` is a no-op) while omitting its rows. Patterns are
+# quoted so the shell does not glob them; pg_dump treats * as a wildcard.
+# PGOPTIONS forces the prod session read-only so pg_dump physically cannot write,
+# on top of pg_dump only ever issuing SELECT/COPY.
+info "Dumping production (read-only)... this can take a moment."
+$DC exec -T -e PGOPTIONS='-c default_transaction_read_only=on' db pg_dump "$PROD_URL" \
+  --no-owner --no-privileges \
+  --exclude-table-data='public.*historical*' \
+  --exclude-table-data='public.constance_*' \
+  --exclude-table-data='public.oauth2_provider_*' \
+  --exclude-table-data='public.oauth_*' \
+  --exclude-table-data='public.core_apikey' \
+  --exclude-table-data='public.accounts_invitation' \
+  --exclude-table-data='public.django_session' \
+  --exclude-table-data='public.django_admin_log' \
+  --exclude-table-data='public.django_q_*' \
+  --exclude-table-data='public.parts_*' \
+  --exclude-table-data='public.wiki_*' \
+  --exclude-table-data='public.discord_*' \
+  --exclude-table-data='public.catalog_machinecomment' \
+  --exclude-table-data='public.catalog_ownercomment' \
+  --exclude-table-data='public.catalog_ownerdocument' \
+  > "$DUMP"
+info "Dump written ($(wc -c < "$DUMP" | tr -d ' ') bytes)."
+
+# --- Recreate the local database (connect via the maintenance 'postgres' db) ---
+info "Recreating local database '${LOCAL_DB}'..."
+$DC exec -T db psql -U flipfix -d postgres -v ON_ERROR_STOP=1 \
+  -c "DROP DATABASE IF EXISTS ${LOCAL_DB} WITH (FORCE);" \
+  -c "CREATE DATABASE ${LOCAL_DB} OWNER flipfix;" >/dev/null
+
+# --- Restore ---
+info "Restoring dump into '${LOCAL_DB}'..."
+$DC exec -T db psql -U flipfix -d "${LOCAL_DB}" -v ON_ERROR_STOP=1 --quiet < "$DUMP" >/dev/null
+
+# --- Sanitize (scrub residual PII; belt-and-suspenders truncations) ---
+info "Sanitizing (scrubbing PII)..."
+$DC exec -T db psql -U flipfix -d "${LOCAL_DB}" -v ON_ERROR_STOP=1 --quiet < scripts/sanitize_dev_db.sql >/dev/null
+
+# --- Migrate (should be a no-op; surfaces branch/prod migration drift) ---
+info "Applying migrations (no-op unless your branch is ahead of prod)..."
+DATABASE_URL="$LOCAL_URL" DJANGO_SETTINGS_MODULE=flipfix.settings.dev \
+  "$PYTHON" manage.py migrate --no-input
+
+# --- Ensure a login exists (all prod passwords were scrubbed) ---
+DEV_SUPERUSER="${DEV_SUPERUSER:-admin}"
+DEV_PASSWORD="${DEV_PASSWORD:-admin}"
+info "Ensuring dev superuser '${DEV_SUPERUSER}' exists..."
+DATABASE_URL="$LOCAL_URL" DJANGO_SETTINGS_MODULE=flipfix.settings.dev \
+  DEV_SUPERUSER="$DEV_SUPERUSER" DEV_PASSWORD="$DEV_PASSWORD" \
+  "$PYTHON" manage.py shell <<'PY'
+import os
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+username = os.environ["DEV_SUPERUSER"]
+password = os.environ["DEV_PASSWORD"]
+user, _ = User.objects.get_or_create(
+    username=username,
+    defaults={"email": f"{username}@example.test"},
+)
+user.is_staff = True
+user.is_superuser = True
+user.is_active = True
+user.set_password(password)
+user.save()
+print(f"  superuser ready: {username}")
+PY
+
+info ""
+info "Done. Local DB '${LOCAL_DB}' now holds sanitized production data."
+info "Log in at http://localhost:8000/admin/ as '${DEV_SUPERUSER}' / '${DEV_PASSWORD}'."
+warn "Media files were not synced — image/video thumbnails will be broken locally."


### PR DESCRIPTION
## What & why

Prototyping the daily maintenance report surfaced that dev has no realistic data — the dev DB is SQLite seeded from curated fixtures, and the only prod→local path (`pull_sample_machines`) pulls just the public machine list. This adds a repeatable **`make sync-prod`** that refreshes a local dev database with a **sanitized** copy of production.

It also moves dev onto **Postgres** (opt-in), ending the SQLite-vs-Postgres engine drift that hides bugs.

## How it works

`make db-up` starts a local Postgres (docker compose, port **54321**). `make sync-prod`:
1. `pg_dump` production **read-only** (`default_transaction_read_only=on`), excluding secret / history / out-of-scope table **data** at dump time so those rows never touch disk.
2. Drops & recreates the local DB, restores the dump.
3. Runs `scripts/sanitize_dev_db.sql` — pattern-based truncation + PII scrub.
4. `migrate` (a no-op; surfaces branch/prod drift).
5. Ensures a dev superuser (all prod passwords are scrubbed).

## Scope & safety

- **Kept ("maintenance core"):** machines, models, locations, owners (contact scrubbed), problem reports (reporter/IP/device scrubbed), log entries, tasks, users/maintainers (emails faked, passwords made unusable).
- **Never copied:** OAuth tokens, `constance` secrets (Discord/Anthropic keys, webhook), API keys, invitations, sessions, django-q payloads, and all `simple_history` audit tables.
- **Media files are not synced** (broken thumbnails locally).
- **Production is only ever read.**

## Notable changes

- `settings/dev.py` runs on Postgres when `DATABASE_URL` is set (SQLite default), read via **python-decouple** so it works from `.env` (not just `os.environ`).
- `ALLOW_SAMPLE_DATA` settings flag replaces the six per-command "SQLite only" guards, so seeding works on Postgres dev but stays blocked in prod/staging.
- Local dev credentials in `docker-compose.yml` / `.env.example` are allowlisted in `.secrets.baseline`.

## Verification

Ran the actual `sync_prod.sh` against a local "fake prod" (seeded via `create_sample_data` + injected secrets/PII). Result: all secret/history/out-of-scope tables → **0 rows**; real gmail emails → `@example.test`; report IPs / reporter names / owner contacts cleared; core data (39 machines, reports, users) intact; `migrate` a no-op. Local gate: **ruff, mypy, 1988 tests, JS tests all green.**

> Note: `docker-compose.yml` pins `postgres:18` (latest stable; client must be ≥ prod's server version) and uses the 18+ volume mount convention (`/var/lib/postgresql`). Verify prod's major and bump if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)