### PR TITLE
feat(dev): sync edit history and more into local dev DB

### DIFF
--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -104,13 +104,16 @@ creates/refreshes this dev superuser; override with `DEV_SUPERUSER` /
 
 **What the sync does and does not include:**
 
-- **Scope:** the "maintenance core" — machines, models, locations, owners
-  (contact details scrubbed), problem reports (reporter/IP/device scrubbed),
-  log entries, maintenance tasks, and users/maintainers (emails faked, passwords
-  made unusable). Parts, wiki, comments, and Discord links are emptied.
-- **Never copied:** OAuth tokens, `constance` secrets (Discord/Anthropic keys,
-  webhook URL), API keys, invitations, sessions, background-job payloads, and the
-  `simple_history` audit tables — excluded at dump time so they never touch disk.
+- **Included:** a realistic copy of production — machines, owners, problem
+  reports, log entries, tasks, parts, wiki, comments, and the `simple_history`
+  edit history — so most dev works against real data.
+- **PII scrubbed** (live rows and their history): user emails/names + passwords,
+  owner contact details, and problem-report reporter/IP/device.
+- **Never copied** (withheld at dump time so they never touch disk): `constance`
+  secrets (Discord/Anthropic keys, webhook URL), OAuth tokens + app
+  registrations, API keys, invitations, sessions, background-job payloads,
+  Discord account links, and owner documents (sensitive attachments; their files
+  aren't synced anyway).
 - **Media files are not synced** — image/video thumbnails will be broken links.
 - **Production is only ever read** (the dump session is forced read-only).
 

--- a/scripts/sanitize_dev_db.sql
+++ b/scripts/sanitize_dev_db.sql
@@ -4,25 +4,24 @@
 -- runs this automatically after restoring the dump into the local Postgres
 -- container. It is idempotent and safe to re-run.
 --
--- Secret/history/out-of-scope table DATA is already excluded at dump time by
--- sync_prod.sh, so the TRUNCATEs below are belt-and-suspenders: they also make
--- this file correct if someone restores a full (un-excluded) dump. Missing
--- tables are skipped rather than erroring, so the file tolerates schema drift.
+-- Policy: dev gets a realistic copy of production — including edit history,
+-- parts, wiki, and comments — with only secrets/live credentials, session/job
+-- state, Discord links, and owner documents withheld, and with personal PII
+-- scrubbed from the tables that carry it (live rows AND their simple_history
+-- shadow tables).
+--
+-- The withheld tables' DATA is already excluded at dump time by sync_prod.sh, so
+-- the TRUNCATEs below are belt-and-suspenders: they also make this file correct
+-- if someone restores a full (un-excluded) dump. Missing tables are skipped
+-- rather than erroring, so the file tolerates schema drift.
 
 BEGIN;
 
--- 1. Empty every table whose data must never exist in a dev environment:
---    live secrets/credentials, sessions, background-job payloads, the
---    django-simple-history shadow tables (which duplicate every past value of
---    the PII scrubbed below), and the apps outside the "maintenance core" scope
---    (parts / wiki / comments / documents / discord).
--- Matched by table-name PATTERN rather than a hardcoded list, so new tables in a
--- dropped app (or a renamed one, e.g. constance_constance vs constance_config)
--- are covered automatically. Only whole apps that are entirely out of scope get a
--- prefix wildcard; the kept "catalog"/"maintenance"/"auth" apps are never
--- wildcarded — their few droppable tables are named explicitly. Every parent's
--- children fall under the same wildcard (or are *historical*), so
--- TRUNCATE ... CASCADE never reaches a kept core table.
+-- 1. Empty tables whose data must never exist in dev: live secrets/credentials,
+--    OAuth tokens + app registrations, sessions, background-job payloads, Discord
+--    account links, and owner documents (sensitive attachments — their files
+--    aren't synced anyway). Matched by name PATTERN so new tables in a withheld
+--    app are covered automatically; kept apps are never wildcarded.
 DO $$
 DECLARE
     tbl text;
@@ -30,19 +29,15 @@ BEGIN
     FOR tbl IN
         SELECT table_name FROM information_schema.tables
         WHERE table_schema = 'public' AND (
-               table_name LIKE '%historical%'          -- simple_history shadow tables
-            OR table_name LIKE 'constance\_%'           -- dynamic settings (secrets)
-            OR table_name LIKE 'oauth2\_provider\_%'    -- OAuth tokens/apps
-            OR table_name LIKE 'oauth\_%'               -- app capability grants
-            OR table_name LIKE 'django\_q\_%'           -- background-job payloads
-            OR table_name LIKE 'parts\_%'               -- out-of-scope app
-            OR table_name LIKE 'wiki\_%'                -- out-of-scope app
-            OR table_name LIKE 'discord\_%'             -- out-of-scope app
+               table_name LIKE 'constance\_%'          -- dynamic settings (secrets)
+            OR table_name LIKE 'oauth2\_provider\_%'   -- OAuth tokens + app registrations
+            OR table_name LIKE 'oauth\_%'              -- OAuth capability grants
+            OR table_name LIKE 'django\_q\_%'          -- background-job payloads
+            OR table_name LIKE 'discord\_%'            -- third-party account links
             OR table_name IN (
                 'core_apikey', 'accounts_invitation',
                 'django_session', 'django_admin_log',
-                'catalog_machinecomment', 'catalog_ownercomment',
-                'catalog_ownerdocument'
+                'catalog_ownerdocument', 'catalog_historicalownerdocument'
             )
         )
     LOOP
@@ -50,29 +45,29 @@ BEGIN
     END LOOP;
 END $$;
 
--- 2. Scrub PII from the kept "maintenance core" tables.
+-- 2. Scrub PII from the tables that carry it — the live row AND its
+--    simple_history shadow (which duplicates every past value).
 
 -- Users: fake emails, drop names, mark passwords unusable. sync_prod.sh sets a
 -- known dev password on a superuser afterwards so you can still log in.
+-- (auth_user has no simple_history shadow table.)
 UPDATE auth_user SET
     email      = 'user' || id || '@example.test',
     first_name = '',
     last_name  = '',
     password   = '!scrubbed';   -- '!' prefix = Django "unusable password"
 
--- Machine owners: clear all direct contact details.
+-- Machine owners: clear all direct contact details (live + history).
 UPDATE catalog_owner SET
-    email             = '',
-    phone             = '',
-    address           = '',
-    alternate_contact = '',
-    notes             = '';
+    email = '', phone = '', address = '', alternate_contact = '', notes = '';
+UPDATE catalog_historicalowner SET
+    email = '', phone = '', address = '', alternate_contact = '', notes = '';
 
--- Visitor-submitted problem reports: clear reporter identity and request metadata.
+-- Visitor-submitted problem reports: clear reporter identity + request metadata
+-- (live + history).
 UPDATE maintenance_problemreport SET
-    reported_by_name    = '',
-    reported_by_contact = '',
-    device_info         = '',
-    ip_address          = NULL;
+    reported_by_name = '', reported_by_contact = '', device_info = '', ip_address = NULL;
+UPDATE maintenance_historicalproblemreport SET
+    reported_by_name = '', reported_by_contact = '', device_info = '', ip_address = NULL;
 
 COMMIT;

--- a/scripts/sync_prod.sh
+++ b/scripts/sync_prod.sh
@@ -4,10 +4,12 @@
 #   make sync-prod            # or: scripts/sync_prod.sh [--yes]
 #
 # What it does:
-#   1. pg_dump production (READ-ONLY), excluding secret / history / out-of-scope
-#      table DATA so those rows never touch your disk.
+#   1. pg_dump production (READ-ONLY). Dev gets a realistic copy — including edit
+#      history, parts, wiki, and comments — with only secrets/credentials,
+#      session/job state, Discord links, and owner documents withheld at dump
+#      time (so those rows never touch your disk).
 #   2. Drop & recreate your LOCAL Postgres database and restore the dump.
-#   3. Run scripts/sanitize_dev_db.sql to scrub residual PII.
+#   3. Run scripts/sanitize_dev_db.sql to scrub PII (live rows and their history).
 #   4. Run migrations (a no-op unless your branch has unapplied migrations).
 #   5. Create/refresh a dev superuser so you can log in (all prod passwords are
 #      scrubbed).
@@ -105,7 +107,6 @@ trap cleanup EXIT
 info "Dumping production (read-only)... this can take a moment."
 $DC exec -T -e PGOPTIONS='-c default_transaction_read_only=on' db pg_dump "$PROD_URL" \
   --no-owner --no-privileges \
-  --exclude-table-data='public.*historical*' \
   --exclude-table-data='public.constance_*' \
   --exclude-table-data='public.oauth2_provider_*' \
   --exclude-table-data='public.oauth_*' \
@@ -114,12 +115,9 @@ $DC exec -T -e PGOPTIONS='-c default_transaction_read_only=on' db pg_dump "$PROD
   --exclude-table-data='public.django_session' \
   --exclude-table-data='public.django_admin_log' \
   --exclude-table-data='public.django_q_*' \
-  --exclude-table-data='public.parts_*' \
-  --exclude-table-data='public.wiki_*' \
   --exclude-table-data='public.discord_*' \
-  --exclude-table-data='public.catalog_machinecomment' \
-  --exclude-table-data='public.catalog_ownercomment' \
   --exclude-table-data='public.catalog_ownerdocument' \
+  --exclude-table-data='public.catalog_historicalownerdocument' \
   > "$DUMP"
 info "Dump written ($(wc -c < "$DUMP" | tr -d ' ') bytes)."
 


### PR DESCRIPTION
## What & why

Follow-up to #361. Iterating on the daily-report prototype surfaced that the sync's "maintenance core" scope excluded the `simple_history` tables — so status-change dates (e.g. *when* a machine was marked down) were unavailable in dev, showing as "Unknown". This broadens `make sync-prod` to a realistic copy of production.

## Now included
`simple_history` edit history, parts, wiki, and comments — so more dev works against real data. PII is scrubbed in the **history shadow tables** too, not just the live rows (owner contact; problem-report reporter/IP/device). `auth_user` has no history table.

## Still withheld (secrets / live state / sensitive)
Excluded at dump time so they never touch disk: `constance` secrets (Discord/Anthropic keys, webhook), OAuth tokens + app registrations, API keys, invitations, sessions, django-q payloads, Discord account links, and owner documents (attachments whose files aren't synced anyway).

## Verification
Re-ran `sync_prod.sh` against production. History populated (218 machine + 773 problem-report records); parts (49) and wiki (18) present; **history PII scrubbed** (0 real contacts/reporters/IPs in the shadow tables); secrets still 0 (constance, OAuth tokens, Discord, owner docs). A machine that was marked broken by hand now resolves its down-date from history instead of showing "Unknown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which production data is included when refreshing local development environments.
  * Documented additional scrubbed and withheld data, including edit history, secrets, tokens, sessions, job payloads, Discord links, and sensitive owner documents.

* **Security & Privacy**
  * Strengthened development database sanitization to reduce exposure of sensitive information.
  * Expanded personal-data scrubbing across historical records and related tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->