### PR TITLE
feat(maintenance): daily report landing page (maintainer-only)

### DIFF
--- a/docs/plans/DailyMaintenanceReport.md
+++ b/docs/plans/DailyMaintenanceReport.md
@@ -3,10 +3,10 @@
 An at-a-glance "emoji board" of every machine's health, grouped by museum area,
 posted to Discord each morning and browsable as a web page.
 
-Status: IN PROGRESS. The health model, zone grouping, report builder, and
-`daily_maintenance_report` management command are implemented
-([`flipfix/apps/maintenance/reports.py`](../../flipfix/apps/maintenance/reports.py)).
-The daily Discord post and the web landing page are the next step.
+Status: IN PROGRESS. The health model, zone grouping, report builder
+([`flipfix/apps/maintenance/reports.py`](../../flipfix/apps/maintenance/reports.py)),
+the `daily_maintenance_report` management command, and the maintainer web landing
+page (`/logs/daily-report/`) are implemented. The daily Discord post is next.
 
 ## Rationale
 
@@ -84,9 +84,10 @@ the surfaces can't drift:
   to the landing page. Posted by a django-q2 `Schedule` (the first recurring job)
   running on the existing `qcluster` worker. The Discord _bot_ is read-only, so
   posting goes through the webhook (`discord/tasks.py`).
-- **Maintainer web landing page** _(planned)_ — the verbose board as HTML, where
-  machines link to their detail page, report mentions link to the report, and
-  durations link to the log entry.
+- **Maintainer web landing page** (`/logs/daily-report/`) — the verbose board as
+  HTML, where machines link to their detail page, report mentions link to the
+  driving report, and durations link to the log entry (a bare history-driven
+  "down" date, with no linkable entry, stays plain text).
 
 ## Rejected alternatives
 

--- a/docs/plans/DailyMaintenanceReport.md
+++ b/docs/plans/DailyMaintenanceReport.md
@@ -84,10 +84,13 @@ the surfaces can't drift:
   to the landing page. Posted by a django-q2 `Schedule` (the first recurring job)
   running on the existing `qcluster` worker. The Discord _bot_ is read-only, so
   posting goes through the webhook (`discord/tasks.py`).
-- **Maintainer web landing page** (`/logs/daily-report/`) — the verbose board as
-  HTML, where machines link to their detail page, report mentions link to the
-  driving report, and durations link to the log entry (a bare history-driven
-  "down" date, with no linkable entry, stays plain text).
+- **Maintainer web landing page** (`/logs/daily-report/`) — the report as HTML:
+  each machine's face runs down the left, then its name (→ machine detail), every
+  open problem listed by severity highest-first (each → its report), and the
+  latest-log date (→ the log entry). A machine with **no open problems shows no
+  date**. Links read as plain text and reveal an underline on hover. (Unlike the
+  Discord digest, the page has no per-zone emoji row and uses the latest-log date
+  rather than the per-state date.)
 
 ## Rejected alternatives
 

--- a/flipfix/apps/maintenance/reports.py
+++ b/flipfix/apps/maintenance/reports.py
@@ -96,6 +96,7 @@ class MachineHealth:
     health: str
     status: str = "good"
     open_priorities: tuple[str, ...] = ()
+    open_reports: tuple[tuple[int, str], ...] = ()  # (report_id, priority) per open report
     # dates (aware datetimes; renderers humanize):
     marked_down_at: datetime | None = None
     report_dates: Mapping[str, datetime] = field(default_factory=dict)
@@ -333,6 +334,7 @@ def build_report(now: datetime | None = None) -> Report:
             health=health,
             status=m.operational_status,
             open_priorities=tuple(r["priority"] for r in reports),
+            open_reports=tuple((r["id"], r["priority"]) for r in reports),
             marked_down_at=m_marked_down,
             report_dates=report_dates,
             last_worked_at=log["occurred_at"] if log else None,

--- a/flipfix/apps/maintenance/tests/test_daily_report_view.py
+++ b/flipfix/apps/maintenance/tests/test_daily_report_view.py
@@ -48,25 +48,38 @@ class DailyReportViewTests(TestDataMixin, TestCase):
         resp = self.client.get(self.url)
         self.assertContains(resp, reverse("maintainer-machine-detail", args=[m.slug]))
 
-    def test_down_machine_links_to_its_report(self):
-        m = create_machine(
-            location=self.workshop, operational_status=S.BROKEN, model=create_machine_model()
-        )
-        pr = create_problem_report(
-            machine=m, priority=P.UNPLAYABLE, status=ProblemReport.Status.OPEN
-        )
+    def test_each_open_problem_listed_by_severity_and_linked(self):
+        m = create_machine(location=self.front, model=create_machine_model())
+        major = create_problem_report(machine=m, priority=P.MAJOR, status=ProblemReport.Status.OPEN)
+        minor = create_problem_report(machine=m, priority=P.MINOR, status=ProblemReport.Status.OPEN)
+        task = create_problem_report(machine=m, priority=P.TASK, status=ProblemReport.Status.OPEN)
         self.client.force_login(self.maintainer_user)
-        resp = self.client.get(self.url)
-        self.assertContains(resp, reverse("problem-report-detail", args=[pr.id]))
+        html = self.client.get(self.url).content.decode()
+        major_url = reverse("problem-report-detail", args=[major.id])
+        minor_url = reverse("problem-report-detail", args=[minor.id])
+        task_url = reverse("problem-report-detail", args=[task.id])
+        for url in (major_url, minor_url, task_url):
+            self.assertIn(url, html)
+        # highest severity first: major before minor before task
+        self.assertLess(html.index(major_url), html.index(minor_url))
+        self.assertLess(html.index(minor_url), html.index(task_url))
 
-    def test_fixing_duration_links_to_log_entry(self):
-        m = create_machine(
-            location=self.workshop, operational_status=S.FIXING, model=create_machine_model()
-        )
-        log = create_log_entry(machine=m, occurred_at=timezone.now() - timedelta(days=1))
+    def test_date_links_to_latest_log_entry(self):
+        m = create_machine(location=self.front, model=create_machine_model())
+        create_problem_report(machine=m, priority=P.MINOR, status=ProblemReport.Status.OPEN)
+        create_log_entry(machine=m, occurred_at=timezone.now() - timedelta(days=10))
+        latest = create_log_entry(machine=m, occurred_at=timezone.now() - timedelta(days=2))
         self.client.force_login(self.maintainer_user)
         resp = self.client.get(self.url)
-        self.assertContains(resp, reverse("log-detail", args=[log.id]))
+        self.assertContains(resp, reverse("log-detail", args=[latest.id]))
+
+    def test_machine_without_problems_has_no_date(self):
+        m = create_machine(location=self.front, model=create_machine_model())
+        log = create_log_entry(machine=m, occurred_at=timezone.now() - timedelta(days=2))
+        self.client.force_login(self.maintainer_user)
+        resp = self.client.get(self.url)
+        # no open problems → no date, so its log entry is not linked
+        self.assertNotContains(resp, reverse("log-detail", args=[log.id]))
 
     def test_hidden_zone_machine_not_rendered(self):
         hidden = create_location("Basement", Z.HIDDEN)

--- a/flipfix/apps/maintenance/tests/test_daily_report_view.py
+++ b/flipfix/apps/maintenance/tests/test_daily_report_view.py
@@ -81,6 +81,16 @@ class DailyReportViewTests(TestDataMixin, TestCase):
         # no open problems → no date, so its log entry is not linked
         self.assertNotContains(resp, reverse("log-detail", args=[log.id]))
 
+    def test_down_machine_with_no_report_shows_no_date(self):
+        # Broken by hand, no open problems: it reads as 😭 but carries no date.
+        m = create_machine(
+            location=self.workshop, operational_status=S.BROKEN, model=create_machine_model()
+        )
+        log = create_log_entry(machine=m, occurred_at=timezone.now() - timedelta(days=2))
+        self.client.force_login(self.maintainer_user)
+        resp = self.client.get(self.url)
+        self.assertNotContains(resp, reverse("log-detail", args=[log.id]))
+
     def test_hidden_zone_machine_not_rendered(self):
         hidden = create_location("Basement", Z.HIDDEN)
         create_machine(location=hidden, name="SecretMachine", model=create_machine_model())

--- a/flipfix/apps/maintenance/tests/test_daily_report_view.py
+++ b/flipfix/apps/maintenance/tests/test_daily_report_view.py
@@ -1,0 +1,76 @@
+"""Tests for the maintainer-only daily report landing page."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.test import TestCase, tag
+from django.urls import reverse
+from django.utils import timezone
+
+from flipfix.apps.catalog.models import Location, MachineInstance
+from flipfix.apps.core.test_utils import (
+    TestDataMixin,
+    create_location,
+    create_log_entry,
+    create_machine,
+    create_machine_model,
+    create_problem_report,
+)
+from flipfix.apps.maintenance.models import ProblemReport
+
+S = MachineInstance.OperationalStatus
+P = ProblemReport.Priority
+Z = Location.Zone
+
+
+@tag("views")
+class DailyReportViewTests(TestDataMixin, TestCase):
+    url = reverse("daily-maintenance-report")
+
+    def setUp(self):
+        super().setUp()
+        self.front = create_location("Coin-Op", Z.FRONT)
+        self.workshop = create_location("Workshop", Z.WORKSHOP)
+
+    def test_requires_login(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn("login", resp.url)
+
+    def test_maintainer_gets_200(self):
+        self.client.force_login(self.maintainer_user)
+        self.assertEqual(self.client.get(self.url).status_code, 200)
+
+    def test_machine_links_to_detail(self):
+        m = create_machine(location=self.front, model=create_machine_model())
+        self.client.force_login(self.maintainer_user)
+        resp = self.client.get(self.url)
+        self.assertContains(resp, reverse("maintainer-machine-detail", args=[m.slug]))
+
+    def test_down_machine_links_to_its_report(self):
+        m = create_machine(
+            location=self.workshop, operational_status=S.BROKEN, model=create_machine_model()
+        )
+        pr = create_problem_report(
+            machine=m, priority=P.UNPLAYABLE, status=ProblemReport.Status.OPEN
+        )
+        self.client.force_login(self.maintainer_user)
+        resp = self.client.get(self.url)
+        self.assertContains(resp, reverse("problem-report-detail", args=[pr.id]))
+
+    def test_fixing_duration_links_to_log_entry(self):
+        m = create_machine(
+            location=self.workshop, operational_status=S.FIXING, model=create_machine_model()
+        )
+        log = create_log_entry(machine=m, occurred_at=timezone.now() - timedelta(days=1))
+        self.client.force_login(self.maintainer_user)
+        resp = self.client.get(self.url)
+        self.assertContains(resp, reverse("log-detail", args=[log.id]))
+
+    def test_hidden_zone_machine_not_rendered(self):
+        hidden = create_location("Basement", Z.HIDDEN)
+        create_machine(location=hidden, name="SecretMachine", model=create_machine_model())
+        self.client.force_login(self.maintainer_user)
+        resp = self.client.get(self.url)
+        self.assertNotContains(resp, "SecretMachine")

--- a/flipfix/apps/maintenance/views/daily_report.py
+++ b/flipfix/apps/maintenance/views/daily_report.py
@@ -1,0 +1,109 @@
+"""Maintainer-only web landing page for the daily maintenance report.
+
+Renders the verbose board from ``reports.build_report`` as HTML, resolving the
+per-machine link targets (machine detail, driving problem report, log entry) that
+the Discord digest can't carry. Maintainer-only: the route omits ``access=``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.urls import reverse
+from django.views.generic import TemplateView
+
+from flipfix.apps.maintenance.reports import (
+    EMOJI,
+    LABELS,
+    STORAGE_BOX,
+    MachineHealth,
+    build_report,
+    humanize_ago,
+    state_date,
+)
+
+
+@dataclass(frozen=True)
+class MachineCell:
+    """A machine prepared for the template, with resolved link URLs."""
+
+    row_glyph: str  # box for storage, health emoji otherwise (for the zone row)
+    emoji: str  # always the real health emoji (for the per-machine list)
+    name: str
+    year: int | None
+    status: str
+    health: str
+    health_label: str
+    reports: str
+    machine_url: str
+    report_url: str | None
+    duration_text: str
+    duration_url: str | None
+
+
+def _report_url(m: MachineHealth) -> str | None:
+    if m.driving_report_id:
+        return reverse("problem-report-detail", args=[m.driving_report_id])
+    return None
+
+
+def _duration_url(m: MachineHealth) -> str | None:
+    """Where the "N ago" duration links.
+
+    Log-based dates (being fixed, and the minor/good fallback) point at the log
+    entry; report-based dates (untriaged/major, and a report-driven "down") point
+    at the driving report. A "down" machine with no report — only a bare history
+    status change — has no linkable entry, so the duration stays plain text.
+    """
+    if m.health in ("untriaged", "major", "down") and m.driving_report_id:
+        return reverse("problem-report-detail", args=[m.driving_report_id])
+    if m.last_log_id:
+        return reverse("log-detail", args=[m.last_log_id])
+    return None
+
+
+def _cell(m: MachineHealth, now, *, as_box: bool) -> MachineCell:
+    return MachineCell(
+        row_glyph=STORAGE_BOX if as_box else EMOJI[m.health],
+        emoji=EMOJI[m.health],
+        name=m.name,
+        year=m.year,
+        status=m.status,
+        health=m.health,
+        health_label=LABELS[m.health],
+        reports=", ".join(sorted(m.open_priorities)) or "none",
+        machine_url=reverse("maintainer-machine-detail", args=[m.slug]),
+        report_url=_report_url(m),
+        duration_text=humanize_ago(state_date(m), now),
+        duration_url=_duration_url(m),
+    )
+
+
+class DailyReportView(TemplateView):
+    """The daily maintenance report as a browsable board (maintainer-only)."""
+
+    template_name = "maintenance/daily_report.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        report = build_report()
+        now = report.generated_at
+        context["zones"] = [
+            {
+                "title": zone.title,
+                "pulse": zone.pulse,
+                "key": zone.key,
+                "rows": [
+                    {
+                        "location_name": row.location_name,
+                        "is_storage": row.is_storage,
+                        "cells": [_cell(c, now, as_box=row.is_storage) for c in row.cells],
+                    }
+                    for row in zone.rows
+                ],
+            }
+            for zone in report.zones
+        ]
+        context["legend"] = report.legend
+        context["generated_at"] = report.generated_at
+        return context

--- a/flipfix/apps/maintenance/views/daily_report.py
+++ b/flipfix/apps/maintenance/views/daily_report.py
@@ -12,70 +12,59 @@ from dataclasses import dataclass
 from django.urls import reverse
 from django.views.generic import TemplateView
 
+from flipfix.apps.maintenance.models import ProblemReport
 from flipfix.apps.maintenance.reports import (
     EMOJI,
-    LABELS,
     STORAGE_BOX,
     MachineHealth,
     build_report,
     humanize_ago,
-    state_date,
 )
+
+# Priority declaration order is severity order (untriaged/unplayable first).
+_SEVERITY = {value: i for i, (value, _) in enumerate(ProblemReport.Priority.choices)}
+
+
+@dataclass(frozen=True)
+class Problem:
+    label: str  # priority name, e.g. "major"
+    url: str  # → problem-report-detail
 
 
 @dataclass(frozen=True)
 class MachineCell:
     """A machine prepared for the template, with resolved link URLs."""
 
-    row_glyph: str  # box for storage, health emoji otherwise (for the zone row)
-    emoji: str  # always the real health emoji (for the per-machine list)
+    glyph: str  # health emoji, or a box for parked storage machines
     name: str
     year: int | None
-    status: str
-    health: str
-    health_label: str
-    reports: str
     machine_url: str
-    report_url: str | None
-    duration_text: str
-    duration_url: str | None
+    problems: list[Problem]  # every open report, most severe first, each linked
+    date_text: str | None  # last-log time, shown only when there are problems
+    date_url: str | None  # → log-detail for the latest log entry
 
 
-def _report_url(m: MachineHealth) -> str | None:
-    if m.driving_report_id:
-        return reverse("problem-report-detail", args=[m.driving_report_id])
-    return None
-
-
-def _duration_url(m: MachineHealth) -> str | None:
-    """Where the "N ago" duration links.
-
-    Log-based dates (being fixed, and the minor/good fallback) point at the log
-    entry; report-based dates (untriaged/major, and a report-driven "down") point
-    at the driving report. A "down" machine with no report — only a bare history
-    status change — has no linkable entry, so the duration stays plain text.
-    """
-    if m.health in ("untriaged", "major", "down") and m.driving_report_id:
-        return reverse("problem-report-detail", args=[m.driving_report_id])
-    if m.last_log_id:
-        return reverse("log-detail", args=[m.last_log_id])
-    return None
+def _problems(m: MachineHealth) -> list[Problem]:
+    ordered = sorted(m.open_reports, key=lambda pr: _SEVERITY.get(pr[1], 99))
+    return [
+        Problem(label=priority, url=reverse("problem-report-detail", args=[report_id]))
+        for report_id, priority in ordered
+    ]
 
 
 def _cell(m: MachineHealth, now, *, as_box: bool) -> MachineCell:
+    has_problems = bool(m.open_reports)
+    # The date is the machine's latest log entry; a machine with no problems
+    # needs no date at all.
+    show_date = has_problems and m.last_log_id is not None
     return MachineCell(
-        row_glyph=STORAGE_BOX if as_box else EMOJI[m.health],
-        emoji=EMOJI[m.health],
+        glyph=STORAGE_BOX if as_box else EMOJI[m.health],
         name=m.name,
         year=m.year,
-        status=m.status,
-        health=m.health,
-        health_label=LABELS[m.health],
-        reports=", ".join(sorted(m.open_priorities)) or "none",
         machine_url=reverse("maintainer-machine-detail", args=[m.slug]),
-        report_url=_report_url(m),
-        duration_text=humanize_ago(state_date(m), now),
-        duration_url=_duration_url(m),
+        problems=_problems(m),
+        date_text=humanize_ago(m.last_worked_at, now) if show_date else None,
+        date_url=reverse("log-detail", args=[m.last_log_id]) if show_date else None,
     )
 
 

--- a/flipfix/static/core/styles.css
+++ b/flipfix/static/core/styles.css
@@ -3665,40 +3665,47 @@ a.stat:focus-visible {
   color: var(--color-text-muted);
   margin-block: var(--space-1) var(--space-2);
 }
-.daily-report__row {
-  display: flex;
-  gap: var(--space-2);
-  align-items: baseline;
-  flex-wrap: wrap;
-}
 .daily-report__location {
-  font-weight: 600;
-  min-width: 8rem;
-}
-.daily-report__glyphs {
-  font-size: 1.25rem;
-  line-height: 1.4;
-}
-.daily-report__glyph {
-  text-decoration: none;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin-block: var(--space-2) var(--space-0-5);
 }
 .daily-report__machines {
   list-style: none;
-  padding-left: var(--space-4);
-  margin-block: var(--space-1) var(--space-3);
+  padding-left: var(--space-2);
+  margin-block: 0 var(--space-3);
 }
 .daily-report__machine {
   padding-block: 0.1rem;
+  line-height: 1.6;
+}
+.daily-report__glyph {
+  display: inline-block;
+  width: 1.6rem;
+}
+/* Comma-separate the problems via CSS so template whitespace can't add a stray
+   space before the comma. */
+.daily-report__problem:not(:last-child)::after {
+  content: ', ';
 }
 .daily-report__year,
-.daily-report__state,
-.daily-report__duration {
+.daily-report__sep {
   color: var(--color-text-muted);
   font-size: var(--text-sm);
+}
+/* Links read as plain text; the underline appears on hover/focus. */
+.daily-report a {
+  color: inherit;
+  text-decoration: none;
+}
+.daily-report a:hover,
+.daily-report a:focus-visible {
+  text-decoration: underline;
 }
 .daily-report__legend {
   color: var(--color-text-muted);
   font-size: var(--text-sm);
   border-top: 1px solid var(--color-border-soft);
   padding-top: var(--space-2);
+  margin-top: var(--space-3);
 }

--- a/flipfix/static/core/styles.css
+++ b/flipfix/static/core/styles.css
@@ -3656,3 +3656,49 @@ a.stat:focus-visible {
   color: var(--color-text-muted);
   margin-top: var(--space-1);
 }
+
+/* ── Daily maintenance report (/logs/daily-report/) ─────────────────────── */
+.daily-report__zone {
+  margin-block: var(--space-4);
+}
+.daily-report__pulse {
+  color: var(--color-text-muted);
+  margin-block: var(--space-1) var(--space-2);
+}
+.daily-report__row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.daily-report__location {
+  font-weight: 600;
+  min-width: 8rem;
+}
+.daily-report__glyphs {
+  font-size: 1.25rem;
+  line-height: 1.4;
+}
+.daily-report__glyph {
+  text-decoration: none;
+}
+.daily-report__machines {
+  list-style: none;
+  padding-left: var(--space-4);
+  margin-block: var(--space-1) var(--space-3);
+}
+.daily-report__machine {
+  padding-block: 0.1rem;
+}
+.daily-report__year,
+.daily-report__state,
+.daily-report__duration {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+.daily-report__legend {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  border-top: 1px solid var(--color-border-soft);
+  padding-top: var(--space-2);
+}

--- a/flipfix/urls.py
+++ b/flipfix/urls.py
@@ -55,6 +55,7 @@ from flipfix.apps.maintenance.views.autocomplete import (
     MaintainerAutocompleteView,
     ProblemReportAutocompleteView,
 )
+from flipfix.apps.maintenance.views.daily_report import DailyReportView
 from flipfix.apps.maintenance.views.labor_report import (
     LaborDetailView,
     LaborWeeklySummaryView,
@@ -494,6 +495,8 @@ urlpatterns = [
     path("logs/", LogListView.as_view(), name="log-list", access="public"),
     # AJAX: infinite scroll for log list
     path("logs/entries/", LogListPartialView.as_view(), name="log-list-entries", access="public"),
+    # Daily maintenance report (emoji health board), maintainer-only
+    path("logs/daily-report/", DailyReportView.as_view(), name="daily-maintenance-report"),
     # Labor report: weekly summary
     path("logs/labor/", LaborWeeklySummaryView.as_view(), name="labor-report-weekly"),
     # Labor report: drill-down detail

--- a/templates/maintenance/daily_report.html
+++ b/templates/maintenance/daily_report.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% load ui_tags %}
+{% block title %}Daily Maintenance · {{ block.super }}{% endblock %}
+{% block content %}
+  <div class="daily-report">
+    <h1>Daily Maintenance</h1>
+    <p class="daily-report__generated">Generated {{ generated_at|smart_date }}</p>
+    {% for zone in zones %}
+      <section class="daily-report__zone">
+        <h2>{{ zone.title }}</h2>
+        <p class="daily-report__pulse">{{ zone.pulse }}</p>
+        {% for row in zone.rows %}
+          <div class="daily-report__row">
+            <span class="daily-report__location">{{ row.location_name }}</span>
+            <span class="daily-report__glyphs">
+              {% for cell in row.cells %}
+                <a href="{{ cell.machine_url }}"
+                   title="{{ cell.name }}"
+                   class="daily-report__glyph">{{ cell.row_glyph }}</a>
+              {% endfor %}
+            </span>
+          </div>
+          <ul class="daily-report__machines">
+            {% for cell in row.cells %}
+              <li class="daily-report__machine">
+                <span class="daily-report__emoji">{{ cell.emoji }}</span>
+                <a href="{{ cell.machine_url }}" class="daily-report__name">{{ cell.name }}</a>
+                <span class="daily-report__year">({{ cell.year|default:"?" }})</span>
+                <span class="daily-report__state">{{ cell.health_label }}</span>
+                {% if cell.report_url %}· <a href="{{ cell.report_url }}">report</a>{% endif %}
+                ·
+                {% if cell.duration_url %}
+                  <a href="{{ cell.duration_url }}">{{ cell.duration_text }}</a>
+                {% else %}
+                  <span class="daily-report__duration">{{ cell.duration_text }}</span>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endfor %}
+      </section>
+    {% endfor %}
+    <p class="daily-report__legend">
+      {% for emoji, label in legend %}
+        <span>{{ emoji }} {{ label }}</span>
+        {% if not forloop.last %}·{% endif %}
+      {% endfor %}
+    </p>
+  </div>
+{% endblock %}

--- a/templates/maintenance/daily_report.html
+++ b/templates/maintenance/daily_report.html
@@ -10,29 +10,24 @@
         <h2>{{ zone.title }}</h2>
         <p class="daily-report__pulse">{{ zone.pulse }}</p>
         {% for row in zone.rows %}
-          <div class="daily-report__row">
-            <span class="daily-report__location">{{ row.location_name }}</span>
-            <span class="daily-report__glyphs">
-              {% for cell in row.cells %}
-                <a href="{{ cell.machine_url }}"
-                   title="{{ cell.name }}"
-                   class="daily-report__glyph">{{ cell.row_glyph }}</a>
-              {% endfor %}
-            </span>
-          </div>
+          <h3 class="daily-report__location">{{ row.location_name }}</h3>
           <ul class="daily-report__machines">
             {% for cell in row.cells %}
               <li class="daily-report__machine">
-                <span class="daily-report__emoji">{{ cell.emoji }}</span>
+                <span class="daily-report__glyph">{{ cell.glyph }}</span>
                 <a href="{{ cell.machine_url }}" class="daily-report__name">{{ cell.name }}</a>
                 <span class="daily-report__year">({{ cell.year|default:"?" }})</span>
-                <span class="daily-report__state">{{ cell.health_label }}</span>
-                {% if cell.report_url %}· <a href="{{ cell.report_url }}">report</a>{% endif %}
-                ·
-                {% if cell.duration_url %}
-                  <a href="{{ cell.duration_url }}">{{ cell.duration_text }}</a>
-                {% else %}
-                  <span class="daily-report__duration">{{ cell.duration_text }}</span>
+                {% if cell.problems %}
+                  <span class="daily-report__sep">·</span>
+                  <span class="daily-report__problems">
+                    {% for problem in cell.problems %}
+                      <a href="{{ problem.url }}" class="daily-report__problem">{{ problem.label }}</a>
+                    {% endfor %}
+                  </span>
+                {% endif %}
+                {% if cell.date_text %}
+                  <span class="daily-report__sep">·</span>
+                  <a href="{{ cell.date_url }}">{{ cell.date_text }}</a>
                 {% endif %}
               </li>
             {% endfor %}


### PR DESCRIPTION
Second PR in the daily-report stack (follows #364). Adds the maintainer-only web landing page; the daily Discord post is the next/final PR.

## What's here
- **`/logs/daily-report/`** — `DailyReportView` (maintainer-only; route omits `access=`, like `labor-report-weekly`) renders the verbose board from `reports.build_report()`.
- Each zone: the emoji row (every machine's glyph links to its detail page; storage renders as 📦) followed by a per-machine breakdown.
- **The three link types:** machine → `maintainer-machine-detail`; report mention → `problem-report-detail` (the driving report); duration → `log-detail`, or the report for untriaged/major/report-driven-down states. A "down" date that comes only from a history status change (no report, no log) stays plain text.
- Reuses the shared builder + `humanize_ago`, so the page and the upcoming Discord digest can't drift.
- Modest CSS using existing design tokens; design-doc status updated.

## Verification
Rendered against **real synced production data** with a real request: 200, 94 machine links, 18 report links, 38 log links, both zones, boxes present. **6 new view tests** (auth 302, maintainer 200, each link type, hidden-zone exclusion); full suite **2039 green**, mypy + djlint clean.

Next PR: `post_daily_maintenance_report` webhook task + the daily `Schedule`, linking to this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a maintainer-only Daily Maintenance report page under the Logs section.
  - Displays machines by zone, machine detail links, open problem reports ordered by severity, and relevant maintenance dates.
  - Links dates to the latest log entry when applicable; unavailable links remain plain text.
  - Excludes machines in hidden zones from the report.

- **Documentation**
  - Updated implementation progress and report output details for the Daily Maintenance feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->