### PR TITLE
fix(sample-data): tolerate a drifted machines.json instead of aborting

### DIFF
--- a/flipfix/apps/core/management/commands/create_sample_infinite_scrolling_data.py
+++ b/flipfix/apps/core/management/commands/create_sample_infinite_scrolling_data.py
@@ -62,13 +62,18 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS("\nGenerating records to test infinite scrolling..."))
 
-        # Find target machine
-        machine = MachineInstance.objects.filter(short_name=self.TARGET_MACHINE_SHORT_NAME).first()
+        # Scroll testing just needs one machine with many records. Prefer the
+        # named target, but fall back to any machine so a drifted machines.json
+        # doesn't abort the seed; only skip when there are no machines at all.
+        machine = (
+            MachineInstance.objects.filter(short_name=self.TARGET_MACHINE_SHORT_NAME).first()
+            or MachineInstance.objects.order_by("id").first()
+        )
         if not machine:
-            raise CommandError(
-                f"Target machine '{self.TARGET_MACHINE_SHORT_NAME}' not found. "
-                "Run create_sample_machines first."
+            self.stdout.write(
+                self.style.WARNING("  No machines exist; skipping infinite-scroll data.")
             )
+            return
 
         # Base time: 200 minutes ago (ensures no future dates)
         base_time = timezone.now() - timedelta(minutes=200)

--- a/flipfix/apps/core/tests/test_sample_data_seeding.py
+++ b/flipfix/apps/core/tests/test_sample_data_seeding.py
@@ -1,0 +1,43 @@
+"""Regression tests: sample-data seeders tolerate a drifted machines.json.
+
+machines.json is regenerated from the prod API, while logs_problems.json /
+part_requests.json / the infinite-scroll target are hand-maintained, so they
+drift. The seeders must skip stale machine references, not abort the whole seed.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase, tag
+
+from flipfix.apps.core.test_utils import TemporaryMediaMixin, create_machine
+from flipfix.apps.maintenance.models import LogEntry, ProblemReport
+from flipfix.apps.parts.models import PartRequest
+
+
+@tag("commands")
+class InfiniteScrollTargetFallbackTests(TestCase):
+    def test_falls_back_to_any_machine_when_named_target_absent(self):
+        # No machine named "Eight Ball 2"; the generator should use this one.
+        machine = create_machine(name="Fallback Machine")
+        call_command("create_sample_infinite_scrolling_data", stdout=StringIO())
+        self.assertGreater(ProblemReport.objects.filter(machine=machine).count(), 0)
+
+    def test_skips_gracefully_when_no_machines_exist(self):
+        out = StringIO()
+        call_command("create_sample_infinite_scrolling_data", stdout=out)
+        self.assertIn("No machines", out.getvalue())
+        self.assertEqual(ProblemReport.objects.count(), 0)
+
+
+@tag("integration")
+class FullSampleSeedTests(TemporaryMediaMixin, TestCase):
+    def test_create_sample_data_completes_despite_drifted_fixtures(self):
+        # Must not raise even though the fixtures reference machines that
+        # machines.json no longer contains; the previously-aborting creators
+        # (log entries, parts) now populate.
+        call_command("create_sample_data", stdout=StringIO())
+        self.assertGreater(LogEntry.objects.count(), 0)
+        self.assertGreater(PartRequest.objects.count(), 0)

--- a/flipfix/apps/maintenance/management/commands/create_sample_logs_problems.py
+++ b/flipfix/apps/maintenance/management/commands/create_sample_logs_problems.py
@@ -200,10 +200,15 @@ class Command(BaseCommand):
 
             machine = self.find_machine(machine_name)
             if not machine:
-                raise CommandError(
-                    f"Machine not found: '{machine_name}'. "
-                    "Run create_sample_machines first or fix logs_problems.json."
+                # machines.json is regenerated from the prod API and drifts from
+                # this hand-maintained fixture; skip the stale reference rather
+                # than aborting the whole seed.
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Skipping problem report — machine not found: '{machine_name}'."
+                    )
                 )
+                continue
 
             # Find reporter
             reporter_name = problem_entry.get("reported_by", "").strip()
@@ -268,10 +273,12 @@ class Command(BaseCommand):
 
             machine = self.find_machine(machine_name)
             if not machine:
-                raise CommandError(
-                    f"Machine not found: '{machine_name}'. "
-                    "Run create_sample_machines first or fix logs_problems.json."
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Skipping log entry — machine not found: '{machine_name}'."
+                    )
                 )
+                continue
 
             if self._create_log_entry(log_entry_data, machine, problem_report=None):
                 display_name = machine.short_name or machine.name

--- a/flipfix/apps/parts/management/commands/create_sample_parts.py
+++ b/flipfix/apps/parts/management/commands/create_sample_parts.py
@@ -190,10 +190,14 @@ class Command(BaseCommand):
             # Find machine (optional for part requests)
             machine = self.find_machine(machine_name) if machine_name else None
             if machine_name and not machine:
-                raise CommandError(
-                    f"Machine not found: '{machine_name}'. "
-                    "Run create_sample_machines first or fix part_requests.json."
+                # machines.json drifts from this hand-maintained fixture; skip the
+                # stale reference rather than aborting the whole seed.
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Skipping part request — machine not found: '{machine_name}'."
+                    )
                 )
+                continue
 
             # Find requester
             requester_name = request_entry.get("requested_by", "").strip()


### PR DESCRIPTION
## Problem
`make sample-data` (the zero-config SQLite onboarding path) aborted partway, leaving a fresh dev DB with problem reports but **0 log entries and 0 parts**. `machines.json` is regenerated from the prod API, while `logs_problems.json`, `part_requests.json`, and the infinite-scroll target machine are hand-maintained — so they drift, and a single stale machine reference raised `CommandError` and killed the whole seed (`create_sample_data` stops on the first creator that raises, so parts and scroll data never ran either).

## Fix
Make the seeders resilient to fixture drift:
- `create_sample_logs_problems` — skip a problem report / log entry whose machine isn't found (warn + continue) instead of raising.
- `create_sample_parts` — same for part requests.
- `create_sample_infinite_scrolling_data` — fall back to *any* machine when the named target ("Eight Ball 2") is absent; only skip when there are no machines at all.

## Result
The full seed now completes cleanly: **reports 35, logs 71, parts 56** (was reports 10, logs 0, parts 0), with warnings naming each skipped stale reference.

## Tests
- Fast: infinite-scroll generator uses a fallback machine when the named target is missing; skips gracefully with no machines.
- Integration (`@tag("integration")`): `create_sample_data` completes despite the drifted fixtures and populates logs + parts.

Full suite 2052 green, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)