### PR TITLE
fix(maintenance): tidy nightly Discord report URL and unknown emoji

### DIFF
--- a/flipfix/apps/discord/tasks.py
+++ b/flipfix/apps/discord/tasks.py
@@ -166,7 +166,8 @@ def post_daily_maintenance_report() -> WebhookDeliveryResult:
         return WebhookDeliveryResult(status="skipped", reason="webhooks globally disabled")
 
     board_url = settings.SITE_URL.rstrip("/") + reverse("daily-maintenance-report")
-    content = _fit_discord_content(render_markdown(build_report()), f"🔗 Full board: {board_url}")
+    # Angle brackets suppress Discord's link-preview embed card.
+    content = _fit_discord_content(render_markdown(build_report()), f"🔗 Full board: <{board_url}>")
     try:
         response = requests.post(
             webhook_url,

--- a/flipfix/apps/maintenance/reports.py
+++ b/flipfix/apps/maintenance/reports.py
@@ -36,7 +36,7 @@ EMOJI = {
     "major": "😟",
     "fixing": "🔧",
     "down": "😭",
-    "unknown": "😐",
+    "unknown": "😶",
 }
 
 LABELS = {
@@ -448,7 +448,8 @@ def render_markdown(report: Report, *, link_url: str | None = None) -> str:
 
     parts = [*blocks, _legend_line(report)]
     if link_url:
-        parts.append(f"🔗 Full board: {link_url}")
+        # Angle brackets suppress Discord's link-preview embed card.
+        parts.append(f"🔗 Full board: <{link_url}>")
     return "\n\n".join(parts)
 
 

--- a/flipfix/apps/maintenance/tests/test_reports_markdown.py
+++ b/flipfix/apps/maintenance/tests/test_reports_markdown.py
@@ -53,6 +53,11 @@ class MarkdownTests(TestCase):
         md = render_markdown(self._report(), link_url="https://flip/report")
         self.assertIn("https://flip/report", md)
 
+    def test_link_wrapped_in_angle_brackets_to_suppress_embed(self):
+        # Discord renders a bare URL as a preview card; angle brackets suppress it.
+        md = render_markdown(self._report(), link_url="https://flip/report")
+        self.assertIn("<https://flip/report>", md)
+
     def test_omits_link_when_no_url(self):
         md = render_markdown(self._report())
         self.assertNotIn("🔗", md)
@@ -61,6 +66,7 @@ class MarkdownTests(TestCase):
         md = render_markdown(self._report())
         self.assertIn("😀 good", md)
         self.assertIn("😭 down", md)
+        self.assertIn("😶 unknown", md)  # face with no mouth
 
     def test_verbose_lists_every_machine_with_inputs(self):
         create_machine(


### PR DESCRIPTION
## Summary

Two small fixes to the nightly Discord maintenance report: wrap the "Full board" URL in angle brackets so Discord suppresses its link-preview embed card, and switch the unknown-health emoji from neutral face (😐) to face-with-no-mouth (😶).

- Angle brackets applied in both places the link line is built: `render_markdown`'s `link_url` footer and the Discord task's own footer.
- The unknown emoji lives in the single `EMOJI` map, so the change flows through the legend, emoji rows, and the verbose view.

## Test plan

- [x] `test_reports_markdown` — added `test_link_wrapped_in_angle_brackets_to_suppress_embed`, extended `test_legend_present` to assert `😶 unknown`
- [x] Full maintenance + discord suites pass (177 tests)
- [ ] Confirm the next posted nightly report renders without a link card and shows 😶 for unknown machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Discord maintenance reports now display “Full board” links without generating automatic link-preview cards.
  - Updated the visual indicator for unknown health status from 😐 to 😶.

- **Tests**
  - Added coverage confirming link-preview suppression and the updated unknown-status indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->